### PR TITLE
chore: QueryDSL 기본 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+### QueryDSL ###
+src/main/generated/
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,10 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
+// QueryDSL 설정
+def querydslVersion = '5.1.0'
+def generatedDir = 'src/main/generated'
+
 group = 'swyp12.team9'
 version = '0.0.1-SNAPSHOT'
 description = 'Demo project for Spring Boot'
@@ -40,6 +44,12 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+	// QueryDSL
+	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -52,4 +62,19 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// QueryDSL Q 클래스 생성 경로 설정
+sourceSets {
+	main.java.srcDirs += [generatedDir]
+}
+
+// QueryDSL 컴파일 시 Q 클래스 생성 디렉토리 설정
+tasks.withType(JavaCompile).configureEach {
+	options.generatedSourceOutputDirectory = file(generatedDir)
+}
+
+// clean 시 생성된 Q 클래스 삭제
+clean {
+	delete file(generatedDir)
 }

--- a/src/main/java/swyp12/team9/server/global/config/QueryDslConfig.java
+++ b/src/main/java/swyp12/team9/server/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package swyp12.team9.server.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 📌 Issues Number
#1 

## 📚 Summary
복잡한 동적 쿼리와 타입 안전한 쿼리 작성을 위해 QueryDSL을 프로젝트에 추가
Spring Data JPA의 메서드 쿼리 방식으로는 복잡한 조건 검색, 동적 필터링, 다중 조인 등을 구현하기 어렵고,
JPQL/Native Query는 문자열 기반이라 컴파일 타임에 오류를 잡기 어려움

QueryDSL을 도입하여 다음과 같은 기능을 지원
- 타입 안전한 쿼리 작성 (컴파일 타임 오류 검증)
- 복잡한 동적 쿼리 구현
- 리팩토링 안전성 보장

## 🧩 As-is
- Spring Data JPA 메서드 쿼리만 사용
  - 복잡한 검색 조건 구현 어려움
  - 동적 쿼리 작성 불가능
  - JPQL 문자열 기반으로 오타 발생 시 런타임 에러

```java
// 복잡한 조건 검색이 어려움
@Query("SELECT u FROM User u WHERE u.status = :status AND u.name LIKE %:name%")
List<User> findByStatusAndName(@Param("status") UserStatus status, @Param("name") String name);
```

## 🚀 To-be
- QueryDSL 설정 완료
  - build.gradle에 QueryDSL 5.1.0 의존성 추가
  - Q 클래스 자동 생성 설정 (src/main/generated)
  - JPAQueryFactory Bean 설정
  - .gitignore에 generated 디렉토리 추가

- 타입 안전하고 가독성 높은 쿼리작성 가능

```java
public List<User> searchUsers(String name, UserStatus status) {
    return queryFactory
        .selectFrom(user)
        .where(
            user.status.eq(status),
            user.name.containsIgnoreCase(name)
        )
        .orderBy(user.createdAt.desc())
        .fetch();
}
```

### 주요 변경사항
1. **build.gradle**
   - QueryDSL 5.1.0 의존성 추가
   - Q 클래스 생성 경로 설정
   - clean 시 generated 디렉토리 삭제 설정

2. **QueryDslConfig.java**
   - JPAQueryFactory Bean 등록
   - EntityManager 주입 설정

3. **.gitignore**
   - src/main/generated/ 디렉토리 제외 추가