### PR TITLE
feat: 엔티티 추가

### DIFF
--- a/src/main/java/swyp12/team9/server/domain/bookmark/model/Bookmark.java
+++ b/src/main/java/swyp12/team9/server/domain/bookmark/model/Bookmark.java
@@ -1,0 +1,34 @@
+package swyp12.team9.server.domain.bookmark.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import swyp12.team9.server.domain.user.model.User;
+import swyp12.team9.server.domain.userlink.model.UserLink;
+import swyp12.team9.server.global.common.entity.BaseEntity;
+
+@Entity
+@Table(name = "bookmarks")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bookmark extends BaseEntity {
+
+    @Id
+    @Column(name = "bookmark_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_link_id", nullable = false)
+    private UserLink userLink;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder
+    public Bookmark(UserLink userLink, User user) {
+        this.userLink = userLink;
+        this.user = user;
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/link/model/Link.java
+++ b/src/main/java/swyp12/team9/server/domain/link/model/Link.java
@@ -1,0 +1,41 @@
+package swyp12.team9.server.domain.link.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import swyp12.team9.server.global.common.entity.BaseEntity;
+
+@Entity
+@Table(name = "links")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Link extends BaseEntity {
+
+    @Id
+    @Column(name = "link_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "url", nullable = false, length = 2048)
+    private String url;
+
+    @Column(name = "title", length = 300)
+    private String title;
+
+    @Column(name = "description", length = 1000)
+    private String description;
+
+    @Column(name = "preview_image_url", length = 1024)
+    private String previewImageUrl;
+
+    @Column(name = "ai_summary", columnDefinition = "TEXT")
+    private String aiSummary;
+
+    @Builder
+    public Link(String url, String title, String description, String previewImageUrl) {
+        this.url = url;
+        this.title = title;
+        this.description = description;
+        this.previewImageUrl = previewImageUrl;
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/reference/model/Reference.java
+++ b/src/main/java/swyp12/team9/server/domain/reference/model/Reference.java
@@ -1,0 +1,40 @@
+package swyp12.team9.server.domain.reference.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import swyp12.team9.server.domain.user.model.User;
+import swyp12.team9.server.global.common.entity.BaseEntity;
+
+@Entity
+@Table(name = "references")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reference extends BaseEntity {
+
+    @Id
+    @Column(name = "reference_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "description", length = 500)
+    private String description;
+
+    @Column(name = "is_public", nullable = false)
+    private Boolean isPublic;
+
+    @Builder
+    public Reference(User user, String title, String description, Boolean isPublic) {
+        this.user = user;
+        this.title = title;
+        this.description = description;
+        this.isPublic = isPublic;
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/referenceuserlink/model/ReferenceUserLink.java
+++ b/src/main/java/swyp12/team9/server/domain/referenceuserlink/model/ReferenceUserLink.java
@@ -1,0 +1,34 @@
+package swyp12.team9.server.domain.referenceuserlink.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import swyp12.team9.server.domain.reference.model.Reference;
+import swyp12.team9.server.domain.userlink.model.UserLink;
+import swyp12.team9.server.global.common.entity.BaseEntity;
+
+@Entity
+@Table(name = "reference_user_links")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReferenceUserLink extends BaseEntity {
+
+    @Id
+    @Column(name = "reference_user_link_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reference_id", nullable = false)
+    private Reference reference;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_link_id", nullable = false)
+    private UserLink userLink;
+
+    @Builder
+    public ReferenceUserLink(Reference reference, UserLink userLink) {
+        this.reference = reference;
+        this.userLink = userLink;
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/user/model/User.java
+++ b/src/main/java/swyp12/team9/server/domain/user/model/User.java
@@ -8,7 +8,6 @@ import swyp12.team9.server.global.common.entity.BaseEntity;
 @Entity
 @Table(name = "users")
 @Getter
-@Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
@@ -58,11 +57,20 @@ public class User extends BaseEntity {
     private String email;
 
     @Builder
-    public User(String email, String password, String name) {
-        this.email = email;
+    public User(String username, String password, String name, String nickname,
+                String introduction, String profileImageUrl, String email,
+                Boolean isLock, Boolean isSocial, SocialProvider socialProvider, UserRole roleType) {
+        this.username = username;
         this.password = password;
         this.name = name;
-       // this.status = UserStatus.ACTIVE;
+        this.nickname = nickname;
+        this.introduction = introduction;
+        this.profileImageUrl = profileImageUrl;
+        this.email = email;
+        this.isLock = isLock;
+        this.isSocial = isSocial;
+        this.socialProvider = socialProvider;
+        this.roleType = roleType;
     }
 
     // 회원 정보 수정

--- a/src/main/java/swyp12/team9/server/domain/user/model/User.java
+++ b/src/main/java/swyp12/team9/server/domain/user/model/User.java
@@ -45,8 +45,14 @@ public class User extends BaseEntity {
 //    @Column(nullable = false, length = 20)
 //    private UserStatus status;
 
-    @Column(name = "nickname")
+    @Column(name = "nickname", length = 50)
     private String nickname;
+
+    @Column(name = "introduction", length = 300)
+    private String introduction;
+
+    @Column(name = "profile_image_url", length = 1024)
+    private String profileImageUrl;
 
     @Column(name = "email", unique = true, length = 100)
     private String email;

--- a/src/main/java/swyp12/team9/server/domain/userlink/model/LinkStatus.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/model/LinkStatus.java
@@ -1,0 +1,6 @@
+package swyp12.team9.server.domain.userlink.model;
+
+public enum LinkStatus {
+    UNREAD,
+    READ
+}

--- a/src/main/java/swyp12/team9/server/domain/userlink/model/UserLink.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/model/UserLink.java
@@ -1,0 +1,87 @@
+package swyp12.team9.server.domain.userlink.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import swyp12.team9.server.domain.link.model.Link;
+import swyp12.team9.server.domain.user.model.User;
+import swyp12.team9.server.global.common.entity.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_links")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserLink extends BaseEntity {
+
+    @Id
+    @Column(name = "user_link_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "link_id", nullable = false)
+    private Link link;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private LinkStatus status;
+
+    @Column(name = "why", length = 500)
+    private String why;
+
+    @Column(name = "is_public", nullable = false)
+    private Boolean isPublic;
+
+    @Column(name = "memo", columnDefinition = "TEXT")
+    private String memo;
+
+    @Column(name = "view_count", nullable = false)
+    private Long viewCount;
+
+    @Column(name = "first_opened_at")
+    private LocalDateTime firstOpenedAt;
+
+    @Column(name = "last_opened_at")
+    private LocalDateTime lastOpenedAt;
+
+    @Builder
+    public UserLink(User user, Link link, String why, Boolean isPublic, String memo) {
+        this.user = user;
+        this.link = link;
+        this.status = LinkStatus.UNREAD;
+        this.why = why;
+        this.isPublic = isPublic;
+        this.memo = memo;
+        this.viewCount = 0L;
+    }
+
+    public void updateUserLink(String why, Boolean isPublic, String memo) {
+        this.why = why;
+        this.isPublic = isPublic;
+        this.memo = memo;
+    }
+
+    public void markAsRead() {
+        if (this.status == LinkStatus.UNREAD) {
+            this.status = LinkStatus.READ;
+            this.firstOpenedAt = LocalDateTime.now();
+        }
+        this.lastOpenedAt = LocalDateTime.now();
+        this.viewCount++;
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
+        this.lastOpenedAt = LocalDateTime.now();
+    }
+
+    public void updatePublicStatus(Boolean isPublic) {
+        this.isPublic = isPublic;
+    }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -62,7 +62,6 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
-<<<<<<< HEAD
   #          google:
   #            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
   #            token-uri: https://oauth2.googleapis.com/token
@@ -84,19 +83,6 @@ spring:
           model: text-embedding-3-small
   elasticsearch:
     uris: http://localhost:9200
-=======
-#          google:
-#            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
-#            token-uri: https://oauth2.googleapis.com/token
-#            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
-#            user-name-attribute: sub
-          #google: 생략 가능
-        # Sring Security가 이미 알고있는 provider들
-        # google, facebook, github
-        # 그래서 따로 google은 추가안해도 된다.
-# Google Console에 등록된 Redirect URI와 불일치 → OAuth2AuthenticationException(GlobalExceptionHandler.java) 발생
-# Google Console에 등록된 Redirect URI와 불일치 → OAuth2AuthenticationException(GlobalExceptionHandler.java) 발생
->>>>>>> a756d0e (refactor : GlobalExceptionHandler로 예외처리 통합)
 
 logging:
   level:


### PR DESCRIPTION
## 📌 Issues Number
- close #12

## 📚 Summary
링크 관리 서비스의 핵심 도메인인 Link, UserLink, Reference, ReferenceUserLink, Bookmark 엔티티를 추가하고,
기존 User 엔티티에 누락된 필드를 보완했습니다.

## 🧩 As-is
- User, JwtRefresh 엔티티만 존재
- User 엔티티에 `introduction`, `profileImageUrl` 필드 없음
- 엔티티에서 클래스 레벨 @Builder와 생성자 레벨 @Builder가 중복되어 사용됨
- 링크 관리를 위한 도메인 모델 부재

## 🚀 To-be
- **5개의 새로운 엔티티 추가:**
  - `Link`: 링크 메타데이터 및 AI 요약 정보 관리
  - `UserLink`: 사용자-링크 관계 및 상태 관리 (읽음/안읽음, 공개 여부, 메모 등)
  - `Reference`: 링크를 그룹화하는 참조 폴더
  - `ReferenceUserLink`: 참조 폴더와 사용자 링크의 다대다 연결
  - `Bookmark`: 사용자의 북마크 관리

- **User 엔티티 개선:**
  - `introduction`, `profileImageUrl` 필드 추가
  - 생성자 파라미터에 모든 필드 포함

- **아키텍처 개선:**
  - 클래스 레벨 @Builder 제거, 생성자 레벨 @Builder만 사용
  - 불필요한 update 메서드 제거 (User 제외)
  - BaseEntity 상속으로 `createdAt`, `updatedAt` 자동 관리

### 🏗️ 엔티티 구조

### 1. Link (링크)
```java
- id (PK)
- url
- title
- description
- previewImageUrl
- aiSummary
- createdAt, updatedAt (BaseEntity)
```

### 2. UserLink (사용자-링크)
```java
- id (PK)
- user (FK -> User)
- link (FK -> Link)
- status (UNREAD, READ)
- why
- isPublic
- memo
- viewCount
- firstOpenedAt, lastOpenedAt
- createdAt, updatedAt (BaseEntity)
```

### 3. Reference (참조 폴더)
```java
- id (PK)
- user (FK -> User)
- title
- description
- isPublic
- createdAt, updatedAt (BaseEntity)
```

### 4. ReferenceUserLink (참조-사용자링크 연결)
```java
- id (PK)
- reference (FK -> Reference)
- userLink (FK -> UserLink)
- createdAt, updatedAt (BaseEntity)
```

### 5. Bookmark (북마크)
```java
- id (PK)
- userLink (FK -> UserLink)
- user (FK -> User)
- createdAt, updatedAt (BaseEntity)
```

### 🎯 설계 원칙

1. **BaseEntity 상속**: 모든 엔티티가 `createdAt`, `updatedAt`를 자동으로 관리
2. **Lazy Loading**: 연관관계는 `FetchType.LAZY`로 성능 최적화
3. **생성자 레벨 Builder**: 필수 필드만 빌더에 노출하여 엔티티 생성 제약