### PR TITLE
feat: UserLink 관련 CRUD 기능 구현 & 모든 API 엔드포인트 통일

### DIFF
--- a/src/main/java/swyp12/team9/server/api/auth/AuthController.java
+++ b/src/main/java/swyp12/team9/server/api/auth/AuthController.java
@@ -7,11 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * 인증 API (Swagger 문서화 용도)
@@ -21,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @Tag(name = "Auth", description = "인증 API (로그인/로그아웃)")
 @RestController
+@RequestMapping("/api/v1")
 public class AuthController {
 
     @Operation(summary = "로그인", description = "username, password로 로그인하여 JWT 토큰 발급")
@@ -29,7 +26,7 @@ public class AuthController {
                     content = @Content(schema = @Schema(implementation = LoginResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 실패 (잘못된 username 또는 password)")
     })
-    @PostMapping("/login")
+    @PostMapping("/auth/login")
     public void login(@RequestBody LoginRequest request) {
         // 실제 로직 없음 - LoginFilter가 처리
         // Swagger 문서화 목적
@@ -41,7 +38,7 @@ public class AuthController {
                     content = @Content(schema = @Schema(implementation = LogoutResponse.class))),
             @ApiResponse(responseCode = "400", description = "유효하지 않은 Refresh 토큰")
     })
-    @PostMapping("/logout")
+    @PostMapping("/auth/logout")
     public void logout(@RequestBody LogoutRequest request) {
         // 실제 로직 없음 - LogoutFilter + RefreshTokenLogoutHandler가 처리
         // Swagger 문서화 목적
@@ -60,9 +57,9 @@ public class AuthController {
                     3. 콜백 URL로 리다이렉트되며 JWT 토큰 발급
 
                     **예시 URL:**
-                    - 네이버: `/oauth2/authorization/naver`
-                    - 구글: `/oauth2/authorization/google`
-                    - 카카오: `/oauth2/authorization/kakao`
+                    - 네이버: `/api/v1/oauth2/authorization/naver`
+                    - 구글: `/api/v1/oauth2/authorization/google`
+                    - 카카오: `/api/v1/oauth2/authorization/kakao`
                     """
     )
     @ApiResponses({

--- a/src/main/java/swyp12/team9/server/api/jwt/JwtController.java
+++ b/src/main/java/swyp12/team9/server/api/jwt/JwtController.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import swyp12.team9.server.api.jwt.dto.JwtResponse;
 import swyp12.team9.server.api.jwt.dto.RefreshRequest;
@@ -19,6 +20,7 @@ import swyp12.team9.server.domain.jwt.service.JwtService;
 
 @Tag(name = "JWT", description = "JWT 토큰 관리 API")
 @RestController
+@RequestMapping("/api/v1")
 public class JwtController {
 
     private final JwtService jwtService;

--- a/src/main/java/swyp12/team9/server/api/recommendation/RecommendationController.java
+++ b/src/main/java/swyp12/team9/server/api/recommendation/RecommendationController.java
@@ -12,7 +12,7 @@ import swyp12.team9.server.domain.recommendation.service.RecommendationService;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/recommend")
+@RequestMapping("/api/v1/recommendations")
 @RequiredArgsConstructor
 public class RecommendationController {
 

--- a/src/main/java/swyp12/team9/server/api/reference/ReferenceApi.java
+++ b/src/main/java/swyp12/team9/server/api/reference/ReferenceApi.java
@@ -12,20 +12,14 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import swyp12.team9.server.api.reference.dto.CreateReferenceRequest;
 import swyp12.team9.server.api.reference.dto.ReferenceResponse;
+import swyp12.team9.server.api.reference.dto.ReferenceType;
 import swyp12.team9.server.api.reference.dto.UpdateReferenceRequest;
 import swyp12.team9.server.global.annotation.CurrentUserId;
 import swyp12.team9.server.global.util.PaginationUtils;
 
-import java.util.List;
-
 /**
  * Reference API 인터페이스
  * 이 인터페이스는 Reference 관련 API 스펙을 정의합니다.
- * 장점:
- * 1. API 스펙이 명확하게 정의됨 (Swagger 어노테이션)
- * 2. 다른 서비스에서 이 인터페이스만 의존하면 API 스펙을 알 수 있음
- * 3. Controller는 이 인터페이스를 구현하여 Swagger를 의존할 필요가 없음
- * 4. API 문서 자동 생성 (Swagger UI)
  */
 @Tag(name = "Reference View", description = "레퍼런스 폴더 관리 API")
 @RequestMapping("/api/v1/references")
@@ -41,23 +35,15 @@ public interface ReferenceApi {
                     description = "레퍼런스 생성 성공",
                     content = @Content(schema = @Schema(implementation = ReferenceResponse.class))
             ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 요청"
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "사용자를 찾을 수 없음"
-            )
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
     @PostMapping
-    swyp12.team9.server.global.common.dto.ApiResponse
-            <ReferenceResponse> createReference(
+    swyp12.team9.server.global.common.dto.ApiResponse<ReferenceResponse> createReference(
             @Valid @RequestBody CreateReferenceRequest request,
             @CurrentUserId Long userId
     );
 
-    //
     @Operation(
             summary = "레퍼런스 단건 조회",
             description = "레퍼런스 ID로 단건 조회합니다. 비공개 레퍼런스는 소유자만 조회 가능합니다."
@@ -68,27 +54,19 @@ public interface ReferenceApi {
                     description = "레퍼런스 조회 성공",
                     content = @Content(schema = @Schema(implementation = ReferenceResponse.class))
             ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "권한 없음 (비공개 레퍼런스)"
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "레퍼런스를 찾을 수 없음"
-            )
+            @ApiResponse(responseCode = "403", description = "권한 없음 (비공개 레퍼런스)"),
+            @ApiResponse(responseCode = "404", description = "레퍼런스를 찾을 수 없음")
     })
     @GetMapping("/{referenceId}")
-    swyp12.team9.server.global.common.dto.ApiResponse
-            <ReferenceResponse> getReference(
+    swyp12.team9.server.global.common.dto.ApiResponse<ReferenceResponse> getReference(
             @Parameter(description = "레퍼런스 ID", required = true, example = "1")
             @PathVariable Long referenceId,
             @CurrentUserId(required = false) Long userId
     );
 
-    //
     @Operation(
             summary = "레퍼런스 수정",
-            description = "레퍼런스 정보를 수정합니다. 소유자만 수정 가능합니다."
+            description = "레퍼런스 정보를 부분 수정합니다. 전달된 필드만 수정되며, 소유자만 수정 가능합니다."
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -96,125 +74,79 @@ public interface ReferenceApi {
                     description = "레퍼런스 수정 성공",
                     content = @Content(schema = @Schema(implementation = ReferenceResponse.class))
             ),
-            @ApiResponse(
-                    responseCode = "400",
-                    description = "잘못된 요청"
-            ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "권한 없음 (소유자가 아님)"
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "레퍼런스를 찾을 수 없음"
-            )
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (소유자가 아님)"),
+            @ApiResponse(responseCode = "404", description = "레퍼런스를 찾을 수 없음")
     })
-    @PutMapping("/{referenceId}")
-    swyp12.team9.server.global.common.dto.ApiResponse
-            <ReferenceResponse> updateReference(
+    @PatchMapping("/{referenceId}")
+    swyp12.team9.server.global.common.dto.ApiResponse<ReferenceResponse> updateReference(
             @Parameter(description = "레퍼런스 ID", required = true, example = "1")
             @PathVariable Long referenceId,
             @Valid @RequestBody UpdateReferenceRequest request,
             @CurrentUserId Long userId
     );
 
-    //
     @Operation(
             summary = "레퍼런스 삭제",
             description = "레퍼런스를 삭제합니다. 소유자만 삭제 가능합니다."
     )
     @ApiResponses(value = {
-            @ApiResponse(
-                    responseCode = "204",
-                    description = "레퍼런스 삭제 성공"
-            ),
-            @ApiResponse(
-                    responseCode = "403",
-                    description = "권한 없음 (소유자가 아님)"
-            ),
-            @ApiResponse(
-                    responseCode = "404",
-                    description = "레퍼런스를 찾을 수 없음"
-            )
+            @ApiResponse(responseCode = "204", description = "레퍼런스 삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (소유자가 아님)"),
+            @ApiResponse(responseCode = "404", description = "레퍼런스를 찾을 수 없음")
     })
     @DeleteMapping("/{referenceId}")
-    swyp12.team9.server.global.common.dto.ApiResponse
-            <Void> deleteReference(
+    swyp12.team9.server.global.common.dto.ApiResponse<Void> deleteReference(
             @Parameter(description = "레퍼런스 ID", required = true, example = "1")
             @PathVariable Long referenceId,
             @CurrentUserId Long userId
     );
 
-    // ========== 커서 기반 페이지네이션 API ==========
+    // ========== 레퍼런스 목록 조회 (통합 API) ==========
 
     @Operation(
-            summary = "나의 레퍼런스 목록 조회 (커서 페이징)",
-            description = "현재 사용자의 레퍼런스를 커서 기반 페이징으로 조회합니다. 무한 스크롤에 적합합니다."
+            summary = "레퍼런스 목록 조회",
+            description = """
+                    레퍼런스 목록을 무한스크롤로 조회합니다.
+
+                    **type 파라미터:**
+                    - `ALL`: 내 전체 레퍼런스 (공개 + 비공개) - 로그인 필요
+                    - `PUBLIC`: 공개 레퍼런스만 - 로그인 불필요
+                    - `PRIVATE`: 내 비공개 레퍼런스만 - 로그인 필요
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요 (ALL, PRIVATE 타입)"),
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
     })
-    @GetMapping("/my")
-    swyp12.team9.server.global.common.dto.ApiResponse
-            <PaginationUtils.Cursor.PageResponse<ReferenceResponse>> getMyReferences(
+    @GetMapping
+    swyp12.team9.server.global.common.dto.ApiResponse<PaginationUtils.Cursor.PageResponse<ReferenceResponse>> getReferences(
+            @Parameter(description = "조회 타입 (ALL: 전체, PUBLIC: 공개, PRIVATE: 비공개)", example = "ALL")
+            @RequestParam(defaultValue = "ALL") ReferenceType type,
             @Parameter(description = "커서 (첫 요청 시 null)", example = "10")
             @RequestParam(required = false) String cursor,
             @Parameter(description = "페이지 크기", example = "20")
             @RequestParam(defaultValue = "20") int size,
-            @CurrentUserId Long userId
+            @CurrentUserId(required = false) Long userId
     );
 
-    @Operation(
-            summary = "공개 레퍼런스 목록 조회 (커서 페이징)",
-            description = "공개된 레퍼런스를 커서 기반 페이징으로 조회합니다."
-    )
-    @GetMapping("/public")
-    swyp12.team9.server.global.common.dto.ApiResponse
-            <PaginationUtils.Cursor.PageResponse<ReferenceResponse>> getPublicReferences(
-            @Parameter(description = "커서 (첫 요청 시 null)", example = "10")
-            @RequestParam(required = false) String cursor,
-            @Parameter(description = "페이지 크기", example = "20")
-            @RequestParam(defaultValue = "20") int size
-    );
-
-    @Operation(
-            summary = "비공개 레퍼런스 목록 조회 (커서 페이징)",
-            description = "현재 사용자의 비공개 레퍼런스를 커서 기반 페이징으로 조회합니다."
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "목록 조회 성공"),
-            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
-    })
-    @GetMapping("/not-public")
-    swyp12.team9.server.global.common.dto.ApiResponse
-            <PaginationUtils.Cursor.PageResponse<ReferenceResponse>> getNotPublicReferences(
-            @Parameter(description = "커서 (첫 요청 시 null)", example = "10")
-            @RequestParam(required = false) String cursor,
-            @Parameter(description = "페이지 크기", example = "20")
-            @RequestParam(defaultValue = "20") int size,
-            @CurrentUserId Long userId
-    );
-
-    // 관리자
     // ========== 관리자 전용 API ==========
 
-    @Operation(
-            summary = "[관리자] 모든 비공개 레퍼런스 조회",
-            description = "관리자만 접근 가능. 모든 사용자의 비공개 레퍼런스를 조회합니다."
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "403", description = "권한 없음 (관리자 아님)")
-    })
-    @PreAuthorize("hasRole('ADMIN')")
-    @GetMapping("/admin/not-public")
-    swyp12.team9.server.global.common.dto.ApiResponse<PaginationUtils.Cursor.PageResponse<ReferenceResponse>> getAllNotPublicReferencesForAdmin(
-            @Parameter(description = "커서 (첫 요청 시 null)", example = "10")
-            @RequestParam(required = false) String cursor,
-            @Parameter(description = "페이지 크기", example = "20")
-            @RequestParam(defaultValue = "20") int size
-    );
-
-
+//    @Operation(
+//            summary = "[관리자] 모든 비공개 레퍼런스 조회",
+//            description = "관리자만 접근 가능. 모든 사용자의 비공개 레퍼런스를 조회합니다."
+//    )
+//    @ApiResponses(value = {
+//            @ApiResponse(responseCode = "200", description = "조회 성공"),
+//            @ApiResponse(responseCode = "403", description = "권한 없음 (관리자 아님)")
+//    })
+//    @PreAuthorize("hasRole('ADMIN')")
+//    @GetMapping("/admin/not-public")
+//    swyp12.team9.server.global.common.dto.ApiResponse<PaginationUtils.Cursor.PageResponse<ReferenceResponse>> getAllNotPublicReferencesForAdmin(
+//            @Parameter(description = "커서 (첫 요청 시 null)", example = "10")
+//            @RequestParam(required = false) String cursor,
+//            @Parameter(description = "페이지 크기", example = "20")
+//            @RequestParam(defaultValue = "20") int size
+//    );
 }

--- a/src/main/java/swyp12/team9/server/api/reference/ReferenceController.java
+++ b/src/main/java/swyp12/team9/server/api/reference/ReferenceController.java
@@ -1,6 +1,5 @@
 package swyp12.team9.server.api.reference;
 
-
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -8,26 +7,26 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import swyp12.team9.server.api.reference.dto.CreateReferenceRequest;
 import swyp12.team9.server.api.reference.dto.ReferenceResponse;
+import swyp12.team9.server.api.reference.dto.ReferenceType;
 import swyp12.team9.server.api.reference.dto.UpdateReferenceRequest;
 import swyp12.team9.server.domain.reference.service.ReferenceService;
 import swyp12.team9.server.global.annotation.CurrentUserId;
 import swyp12.team9.server.global.common.dto.ApiResponse;
 import swyp12.team9.server.global.util.PaginationUtils;
 
-import java.util.List;
-
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/references")
 @RequiredArgsConstructor
-public class ReferenceController implements ReferenceApi{
+public class ReferenceController implements ReferenceApi {
 
     private final ReferenceService referenceService;
 
     // 레퍼런스 생성
     @Override
-    public ApiResponse<ReferenceResponse> createReference(@Valid @RequestBody CreateReferenceRequest request,
-                                                         @CurrentUserId Long userId) {
+    public ApiResponse<ReferenceResponse> createReference(
+            @Valid @RequestBody CreateReferenceRequest request,
+            @CurrentUserId Long userId) {
 
         ReferenceResponse response = referenceService.createReference(userId, request);
         return ApiResponse.created(response, "레퍼런스 폴더가 생성되었습니다.");
@@ -64,56 +63,31 @@ public class ReferenceController implements ReferenceApi{
         return ApiResponse.noContent();
     }
 
-    // ========== 커서 기반 페이지네이션 ==========
-    // 내 레퍼런스 목록 조회
+    // ========== 레퍼런스 목록 조회 (통합 API) ==========
     @Override
-    public ApiResponse<PaginationUtils.Cursor.PageResponse<ReferenceResponse>> getMyReferences(
+    public ApiResponse<PaginationUtils.Cursor.PageResponse<ReferenceResponse>> getReferences(
+            @RequestParam(defaultValue = "ALL") ReferenceType type,
             @RequestParam(required = false) String cursor,
             @RequestParam(defaultValue = "20") int size,
-            @CurrentUserId Long userId) {
+            @CurrentUserId(required = false) Long userId) {
 
         PaginationUtils.Cursor.PageResponse<ReferenceResponse> response =
-                referenceService.getUserReferencesCursor(userId, cursor, size);
-        return ApiResponse.ok(response);
-    }
-
-    // 공개 레퍼런스 목록 조회
-    @Override
-    public ApiResponse<PaginationUtils.Cursor.PageResponse<ReferenceResponse>> getPublicReferences(
-            @RequestParam(required = false) String cursor,
-            @RequestParam(defaultValue = "20") int size) {
-
-        PaginationUtils.Cursor.PageResponse<ReferenceResponse> response =
-                referenceService.getPublicReferencesCursor(cursor, size);
-        return ApiResponse.ok(response);
-    }
-
-    // 비공개 레퍼런스 목록 조회
-    @Override
-    public ApiResponse<PaginationUtils.Cursor.PageResponse<ReferenceResponse>> getNotPublicReferences(
-            @RequestParam(required = false) String cursor,
-            @RequestParam(defaultValue = "20") int size,
-            @CurrentUserId Long userId) {
-
-        PaginationUtils.Cursor.PageResponse<ReferenceResponse> response =
-                referenceService.getNotPublicReferencesCursor(userId, cursor, size);
+                referenceService.getReferences(userId, type, cursor, size);
         return ApiResponse.ok(response);
     }
 
     // ========== 관리자 전용 API ==========
-
-    @Override
-    @PreAuthorize("hasRole('ADMIN')")
-    public ApiResponse<PaginationUtils.Cursor.PageResponse<ReferenceResponse>> getAllNotPublicReferencesForAdmin(
-            @RequestParam(required = false) String cursor,
-            @RequestParam(defaultValue = "20") int size) {
-
-        log.info("관리자 비공개 레퍼런스 조회 요청 - cursor: {}, size: {}", cursor, size);
-
-        PaginationUtils.Cursor.PageResponse<ReferenceResponse> response =
-                referenceService.getAllNotPublicReferencesCursor(cursor, size);
-
-        return ApiResponse.ok(response, "관리자 비공개 레퍼런스 조회 완료");
-    }
-
+//    @Override
+//    @PreAuthorize("hasRole('ADMIN')")
+//    public ApiResponse<PaginationUtils.Cursor.PageResponse<ReferenceResponse>> getAllNotPublicReferencesForAdmin(
+//            @RequestParam(required = false) String cursor,
+//            @RequestParam(defaultValue = "20") int size) {
+//
+//        log.info("관리자 비공개 레퍼런스 조회 요청 - cursor: {}, size: {}", cursor, size);
+//
+//        PaginationUtils.Cursor.PageResponse<ReferenceResponse> response =
+//                referenceService.getAllNotPublicReferences(cursor, size);
+//
+//        return ApiResponse.ok(response, "관리자 비공개 레퍼런스 조회 완료");
+//    }
 }

--- a/src/main/java/swyp12/team9/server/api/reference/dto/ReferenceType.java
+++ b/src/main/java/swyp12/team9/server/api/reference/dto/ReferenceType.java
@@ -1,0 +1,15 @@
+package swyp12.team9.server.api.reference.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "레퍼런스 조회 타입")
+public enum ReferenceType {
+    @Schema(description = "전체 (공개 + 비공개)")
+    ALL,
+
+    @Schema(description = "공개만")
+    PUBLIC,
+
+    @Schema(description = "비공개만")
+    PRIVATE
+}

--- a/src/main/java/swyp12/team9/server/api/user/UserController.java
+++ b/src/main/java/swyp12/team9/server/api/user/UserController.java
@@ -30,7 +30,7 @@ import swyp12.team9.server.global.annotation.CurrentUserId;
 @Tag(name = "User", description = "사용자 관리 API")
 @Slf4j
 @RestController
-@RequestMapping("/api/users")
+@RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
 public class UserController {
 
@@ -69,7 +69,7 @@ public class UserController {
                     content = @Content(schema = @Schema(implementation = UserResponse.class))),
             @ApiResponse(responseCode = "401", description = "인증 실패 (토큰 없음 또는 만료)")
     })
-    @GetMapping(value = "/user")
+    @GetMapping(value = "/info")
     public UserResponse userMe(@CurrentUserId Long userId) {
         return userService.readUser(userId);
     }
@@ -98,7 +98,7 @@ public class UserController {
                     content = @Content(schema = @Schema(implementation = Boolean.class))),
             @ApiResponse(responseCode = "401", description = "인증 실패 (토큰 없음 또는 만료)")
     })
-    @DeleteMapping(value = "/delete")
+    @DeleteMapping
     public ResponseEntity<Boolean> deleteUser(@CurrentUserId Long userId) {
         userService.deleteUser(userId);
         return ResponseEntity.status(HttpStatus.OK).body(true);

--- a/src/main/java/swyp12/team9/server/api/userlink/UserLinkApi2.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/UserLinkApi2.java
@@ -1,0 +1,153 @@
+package swyp12.team9.server.api.userlink;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+import swyp12.team9.server.api.userlink.dto.CreateUserLinkRequest;
+import swyp12.team9.server.api.userlink.dto.UpdateUserLinkRequest;
+import swyp12.team9.server.api.userlink.dto.UserLinkResponse;
+import swyp12.team9.server.api.userlink.dto.UserLinkType;
+import swyp12.team9.server.global.annotation.CurrentUserId;
+import swyp12.team9.server.global.util.PaginationUtils;
+
+/**
+ * UserLink API 인터페이스
+ * 사용자 링크 관련 API 스펙을 정의합니다.
+ */
+@Tag(name = "UserLink", description = "사용자 링크 관리 API")
+@RequestMapping("/api/v1/user-links")
+public interface UserLinkApi2 {
+
+    @Operation(
+            summary = "링크 게시물 생성",
+            description = "새로운 링크를 저장합니다. URL로 기존 Link가 있으면 재사용하고, 없으면 새로 생성합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "링크 저장 성공",
+                    content = @Content(schema = @Schema(implementation = UserLinkResponse.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 URL 등)"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @PostMapping
+    swyp12.team9.server.global.common.dto.ApiResponse<UserLinkResponse> createUserLink(
+            @Valid @RequestBody CreateUserLinkRequest request,
+            @CurrentUserId Long userId
+    );
+
+    @Operation(
+            summary = "링크 게시물 단건 조회",
+            description = "링크 ID로 단건 조회합니다. 비공개 링크는 소유자만 조회 가능합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(schema = @Schema(implementation = UserLinkResponse.class))
+            ),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (비공개 링크)"),
+            @ApiResponse(responseCode = "404", description = "링크를 찾을 수 없음")
+    })
+    @GetMapping("/{userLinkId}")
+    swyp12.team9.server.global.common.dto.ApiResponse<UserLinkResponse> getUserLink(
+            @Parameter(description = "사용자 링크 ID", required = true, example = "1")
+            @PathVariable Long userLinkId,
+            @CurrentUserId(required = false) Long userId
+    );
+
+    @Operation(
+            summary = "링크 게시물 수정",
+            description = "링크 정보를 부분 수정합니다. 전달된 필드만 수정되며, 소유자만 수정 가능합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "수정 성공",
+                    content = @Content(schema = @Schema(implementation = UserLinkResponse.class))
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (소유자가 아님)"),
+            @ApiResponse(responseCode = "404", description = "링크를 찾을 수 없음")
+    })
+    @PatchMapping("/{userLinkId}")
+    swyp12.team9.server.global.common.dto.ApiResponse<UserLinkResponse> updateUserLink(
+            @Parameter(description = "사용자 링크 ID", required = true, example = "1")
+            @PathVariable Long userLinkId,
+            @Valid @RequestBody UpdateUserLinkRequest request,
+            @CurrentUserId Long userId
+    );
+
+    @Operation(
+            summary = "링크 게시물 삭제",
+            description = "링크를 삭제합니다. 소유자만 삭제 가능합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (소유자가 아님)"),
+            @ApiResponse(responseCode = "404", description = "링크를 찾을 수 없음")
+    })
+    @DeleteMapping("/{userLinkId}")
+    swyp12.team9.server.global.common.dto.ApiResponse<Void> deleteUserLink(
+            @Parameter(description = "사용자 링크 ID", required = true, example = "1")
+            @PathVariable Long userLinkId,
+            @CurrentUserId Long userId
+    );
+
+    @Operation(
+            summary = "링크 게시물 열람(읽음) 처리",
+            description = "링크 게시물을 열람 상태로 변경하고 조회수를 증가시킵니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "열람 처리 성공",
+                    content = @Content(schema = @Schema(implementation = UserLinkResponse.class))
+            ),
+            @ApiResponse(responseCode = "403", description = "권한 없음"),
+            @ApiResponse(responseCode = "404", description = "링크를 찾을 수 없음")
+    })
+    @PostMapping("/{userLinkId}/read")
+    swyp12.team9.server.global.common.dto.ApiResponse<UserLinkResponse> markAsRead(
+            @Parameter(description = "사용자 링크 ID", required = true, example = "1")
+            @PathVariable Long userLinkId,
+            @CurrentUserId Long userId
+    );
+
+    // ========== 사용자 링크 목록 조회 (통합 API) ==========
+
+    @Operation(
+            summary = "링크 게시물 목록 조회",
+            description = """
+                    링크 목록을 무한스크롤로 조회합니다.
+
+                    **type 파라미터:**
+                    - `ALL`: 내 전체 링크 (공개 + 비공개) - 로그인 필요
+                    - `PUBLIC`: 공개 링크만 - 로그인 불필요
+                    - `PRIVATE`: 내 비공개 링크만 - 로그인 필요
+                    """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요 (ALL, PRIVATE 타입)"),
+            @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음")
+    })
+    @GetMapping
+    swyp12.team9.server.global.common.dto.ApiResponse<PaginationUtils.Cursor.PageResponse<UserLinkResponse>> getUserLinks(
+            @Parameter(description = "조회 타입 (ALL: 전체, PUBLIC: 공개, PRIVATE: 비공개)", example = "ALL")
+            @RequestParam(defaultValue = "ALL") UserLinkType type,
+            @Parameter(description = "커서 (첫 요청 시 null)", example = "10")
+            @RequestParam(required = false) String cursor,
+            @Parameter(description = "페이지 크기", example = "20")
+            @RequestParam(defaultValue = "20") int size,
+            @CurrentUserId(required = false) Long userId
+    );
+}

--- a/src/main/java/swyp12/team9/server/api/userlink/UserLinkController.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/UserLinkController.java
@@ -1,0 +1,87 @@
+package swyp12.team9.server.api.userlink;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import swyp12.team9.server.api.userlink.dto.CreateUserLinkRequest;
+import swyp12.team9.server.api.userlink.dto.UpdateUserLinkRequest;
+import swyp12.team9.server.api.userlink.dto.UserLinkResponse;
+import swyp12.team9.server.api.userlink.dto.UserLinkType;
+import swyp12.team9.server.domain.userlink.service.UserLinkService;
+import swyp12.team9.server.global.annotation.CurrentUserId;
+import swyp12.team9.server.global.common.dto.ApiResponse;
+import swyp12.team9.server.global.util.PaginationUtils;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/user-links")
+@RequiredArgsConstructor
+public class UserLinkController implements UserLinkApi {
+
+    private final UserLinkService userLinkService;
+
+    // 사용자 링크 생성
+    @Override
+    public ApiResponse<UserLinkResponse> createUserLink(
+            @Valid @RequestBody CreateUserLinkRequest request,
+            @CurrentUserId Long userId) {
+
+        UserLinkResponse response = userLinkService.createUserLink(userId, request);
+        return ApiResponse.created(response, "링크가 저장되었습니다.");
+    }
+
+    // 사용자 링크 단건 조회
+    @Override
+    public ApiResponse<UserLinkResponse> getUserLink(
+            @PathVariable Long userLinkId,
+            @CurrentUserId(required = false) Long userId) {
+
+        UserLinkResponse response = userLinkService.getUserLink(userId, userLinkId);
+        return ApiResponse.ok(response);
+    }
+
+    // 사용자 링크 수정
+    @Override
+    public ApiResponse<UserLinkResponse> updateUserLink(
+            @PathVariable Long userLinkId,
+            @Valid @RequestBody UpdateUserLinkRequest request,
+            @CurrentUserId Long userId) {
+
+        UserLinkResponse response = userLinkService.updateUserLink(userId, userLinkId, request);
+        return ApiResponse.ok(response, "링크가 수정되었습니다.");
+    }
+
+    // 사용자 링크 삭제
+    @Override
+    public ApiResponse<Void> deleteUserLink(
+            @PathVariable Long userLinkId,
+            @CurrentUserId Long userId) {
+
+        userLinkService.deleteUserLink(userId, userLinkId);
+        return ApiResponse.noContent();
+    }
+
+    // 사용자 링크 읽음 처리
+    @Override
+    public ApiResponse<UserLinkResponse> markAsRead(
+            @PathVariable Long userLinkId,
+            @CurrentUserId Long userId) {
+
+        UserLinkResponse response = userLinkService.markAsRead(userId, userLinkId);
+        return ApiResponse.ok(response, "링크를 읽음 처리했습니다.");
+    }
+
+    // ========== 사용자 링크 목록 조회 (통합 API) ==========
+    @Override
+    public ApiResponse<PaginationUtils.Cursor.PageResponse<UserLinkResponse>> getUserLinks(
+            @RequestParam(defaultValue = "ALL") UserLinkType type,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "20") int size,
+            @CurrentUserId(required = false) Long userId) {
+
+        PaginationUtils.Cursor.PageResponse<UserLinkResponse> response =
+                userLinkService.getUserLinksCursor(userId, type, cursor, size);
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/swyp12/team9/server/api/userlink/UserLinkController2.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/UserLinkController2.java
@@ -8,7 +8,7 @@ import swyp12.team9.server.api.userlink.dto.CreateUserLinkRequest;
 import swyp12.team9.server.api.userlink.dto.UpdateUserLinkRequest;
 import swyp12.team9.server.api.userlink.dto.UserLinkResponse;
 import swyp12.team9.server.api.userlink.dto.UserLinkType;
-import swyp12.team9.server.domain.userlink.service.UserLinkService;
+import swyp12.team9.server.domain.userlink.service.UserLinkService2;
 import swyp12.team9.server.global.annotation.CurrentUserId;
 import swyp12.team9.server.global.common.dto.ApiResponse;
 import swyp12.team9.server.global.util.PaginationUtils;
@@ -17,9 +17,9 @@ import swyp12.team9.server.global.util.PaginationUtils;
 @RestController
 @RequestMapping("/api/v1/user-links")
 @RequiredArgsConstructor
-public class UserLinkController implements UserLinkApi {
+public class UserLinkController2 implements UserLinkApi2 {
 
-    private final UserLinkService userLinkService;
+    private final UserLinkService2 userLinkService;
 
     // 사용자 링크 생성
     @Override
@@ -72,7 +72,7 @@ public class UserLinkController implements UserLinkApi {
         return ApiResponse.ok(response, "링크를 읽음 처리했습니다.");
     }
 
-    // ========== 사용자 링크 목록 조회 (통합 API) ==========
+    // 사용자 링크 목록 조회 (통합 API - 전체, 공개, 비공기)
     @Override
     public ApiResponse<PaginationUtils.Cursor.PageResponse<UserLinkResponse>> getUserLinks(
             @RequestParam(defaultValue = "ALL") UserLinkType type,
@@ -81,7 +81,7 @@ public class UserLinkController implements UserLinkApi {
             @CurrentUserId(required = false) Long userId) {
 
         PaginationUtils.Cursor.PageResponse<UserLinkResponse> response =
-                userLinkService.getUserLinksCursor(userId, type, cursor, size);
+                userLinkService.getUserLinks(userId, type, cursor, size);
         return ApiResponse.ok(response);
     }
 }

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/CreateUserLinkRequest.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/CreateUserLinkRequest.java
@@ -1,0 +1,51 @@
+package swyp12.team9.server.api.userlink.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.URL;
+
+@Schema(description = "사용자 링크 생성 요청 객체")
+public record CreateUserLinkRequest(
+
+        @Schema(
+                description = "링크를 저장하는 이유",
+                example = "좋은 아티클이라서 나중에 다시 읽으려고",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        @Size(max = 500, message = "이유는 500자를 초과할 수 없습니다.")
+        String why,
+
+        @Schema(
+                description = "저장할 링크 URL",
+                example = "https://example.com/article",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotBlank(message = "URL은 필수입니다.")
+        @URL(message = "유효한 URL 형식이어야 합니다.")
+        String url,
+
+        @Schema(
+                description = "공개 여부",
+                example = "true",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotNull(message = "공개여부는 필수입니다.")
+        Boolean isPublic,
+
+        @Schema(
+                description = "레퍼런스 폴더 선택",
+                example = "경제",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        String referenceType,
+
+        @Schema(
+                description = "메모",
+                example = "핵심 내용: 경제 패턴에 대한 설명",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        String memo
+) {
+}

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/UpdateUserLinkRequest.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/UpdateUserLinkRequest.java
@@ -1,0 +1,31 @@
+package swyp12.team9.server.api.userlink.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "사용자 링크 수정 요청 객체")
+public record UpdateUserLinkRequest(
+
+        @Schema(
+                description = "링크를 저장하는 이유",
+                example = "좋은 아티클이라서 나중에 다시 읽으려고",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        @Size(max = 500, message = "이유는 500자를 초과할 수 없습니다.")
+        String why,
+
+        @Schema(
+                description = "공개 여부 (생략 시 기존값 유지)",
+                example = "true",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        Boolean isPublic,
+
+        @Schema(
+                description = "메모 (생략 시 기존값 유지)",
+                example = "핵심 내용: 디자인 패턴에 대한 설명",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        String memo
+) {
+}

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/UserLinkListResponse.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/UserLinkListResponse.java
@@ -1,0 +1,79 @@
+package swyp12.team9.server.api.userlink.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import swyp12.team9.server.domain.userlink.model.LinkStatus;
+import swyp12.team9.server.domain.userlink.model.UserLink;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Schema(description = "사용자 링크 응답 객체")
+public record UserLinkListResponse(
+
+        @Schema(description = "사용자 링크 ID", example = "1")
+        Long id,
+
+        @Schema(description = "링크 ID", example = "10")
+        Long linkId,
+
+        @Schema(description = "링크가 속한 카테고리", example = "요리")
+        String category,
+
+        @Schema(description = "링크 제목", example = "디자인 패턴 가이드")
+        String title,
+
+        @Schema(description = "링크 URL", example = "https://example.com/article")
+        String url,
+
+//        @Schema(description = "미리보기 이미지 URL", example = "https://example.com/preview.jpg")
+//        String previewImageUrl,
+
+        @Schema(description = "읽음 상태", example = "UNREAD")
+        LinkStatus status,
+
+//        @Schema(description = "저장 이유", example = "좋은 아티클이라서")
+//        String why,
+
+        @Schema(description = "공개 여부", example = "true")
+        Boolean isPublic,
+
+        @Schema(description = "메모", example = "핵심 내용 정리")
+        String memo,
+
+        @Schema(description = "조회수", example = "5")
+        Long viewCount,
+
+        @Schema(description = "첫 열람 시간", example = "2024-01-15T10:30:00")
+        LocalDateTime firstOpenedAt,
+
+        @Schema(description = "마지막 열람 시간", example = "2024-01-20T14:20:00")
+        LocalDateTime lastOpenedAt,
+
+        @Schema(description = "생성일시", example = "2024-01-10T09:00:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일시", example = "2024-01-15T11:00:00")
+        LocalDateTime updatedAt
+) {
+
+    public static UserLinkResponse from(UserLink userLink) {
+        return UserLinkResponse.builder()
+                .id(userLink.getId())
+                .linkId(userLink.getLink().getId())
+                .url(userLink.getLink().getUrl())
+                .title(userLink.getLink().getTitle())
+                .description(userLink.getLink().getDescription())
+                .previewImageUrl(userLink.getLink().getPreviewImageUrl())
+                .status(userLink.getStatus())
+                .why(userLink.getWhy())
+                .isPublic(userLink.getIsPublic())
+                .memo(userLink.getMemo())
+                .viewCount(userLink.getViewCount())
+                .firstOpenedAt(userLink.getFirstOpenedAt())
+                .lastOpenedAt(userLink.getLastOpenedAt())
+                .createdAt(userLink.getCreatedAt())
+                .updatedAt(userLink.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/UserLinkResponse.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/UserLinkResponse.java
@@ -1,0 +1,79 @@
+package swyp12.team9.server.api.userlink.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import swyp12.team9.server.domain.userlink.model.LinkStatus;
+import swyp12.team9.server.domain.userlink.model.UserLink;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Schema(description = "사용자 링크 응답 객체")
+public record UserLinkResponse(
+
+        @Schema(description = "사용자 링크 ID", example = "1")
+        Long id,
+
+        @Schema(description = "링크 ID", example = "10")
+        Long linkId,
+
+        @Schema(description = "링크 URL", example = "https://example.com/article")
+        String url,
+
+        @Schema(description = "링크 제목", example = "디자인 패턴 가이드")
+        String title,
+
+        @Schema(description = "링크 설명", example = "디자인 패턴에 대한 종합 가이드")
+        String description,
+
+        @Schema(description = "미리보기 이미지 URL", example = "https://example.com/preview.jpg")
+        String previewImageUrl,
+
+        @Schema(description = "읽음 상태", example = "UNREAD")
+        LinkStatus status,
+
+        @Schema(description = "저장 이유", example = "좋은 아티클이라서")
+        String why,
+
+        @Schema(description = "공개 여부", example = "true")
+        Boolean isPublic,
+
+        @Schema(description = "메모", example = "핵심 내용 정리")
+        String memo,
+
+        @Schema(description = "조회수", example = "5")
+        Long viewCount,
+
+        @Schema(description = "첫 열람 시간", example = "2024-01-15T10:30:00")
+        LocalDateTime firstOpenedAt,
+
+        @Schema(description = "마지막 열람 시간", example = "2024-01-20T14:20:00")
+        LocalDateTime lastOpenedAt,
+
+        @Schema(description = "생성일시", example = "2024-01-10T09:00:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일시", example = "2024-01-15T11:00:00")
+        LocalDateTime updatedAt
+) {
+
+    public static UserLinkResponse from(UserLink userLink) {
+        return UserLinkResponse.builder()
+                .id(userLink.getId())
+                .linkId(userLink.getLink().getId())
+                .url(userLink.getLink().getUrl())
+                .title(userLink.getLink().getTitle())
+                .description(userLink.getLink().getDescription())
+                .previewImageUrl(userLink.getLink().getPreviewImageUrl())
+                .status(userLink.getStatus())
+                .why(userLink.getWhy())
+                .isPublic(userLink.getIsPublic())
+                .memo(userLink.getMemo())
+                .viewCount(userLink.getViewCount())
+                .firstOpenedAt(userLink.getFirstOpenedAt())
+                .lastOpenedAt(userLink.getLastOpenedAt())
+                .createdAt(userLink.getCreatedAt())
+                .updatedAt(userLink.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/UserLinkType.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/UserLinkType.java
@@ -1,0 +1,15 @@
+package swyp12.team9.server.api.userlink.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 링크 조회 타입")
+public enum UserLinkType {
+    @Schema(description = "전체 (공개 + 비공개)")
+    ALL,
+
+    @Schema(description = "공개만")
+    PUBLIC,
+
+    @Schema(description = "비공개만")
+    PRIVATE
+}

--- a/src/main/java/swyp12/team9/server/domain/link/repository/LinkRepository2.java
+++ b/src/main/java/swyp12/team9/server/domain/link/repository/LinkRepository2.java
@@ -1,0 +1,21 @@
+package swyp12.team9.server.domain.link.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import swyp12.team9.server.domain.link.model.Link;
+
+import java.util.Optional;
+
+@Repository
+public interface LinkRepository2 extends JpaRepository<Link, Long> {
+
+    /**
+     * URL로 Link 조회
+     */
+    Optional<Link> findByUrl(String url);
+
+    /**
+     * URL 존재 여부 확인
+     */
+    boolean existsByUrl(String url);
+}

--- a/src/main/java/swyp12/team9/server/domain/reference/service/ReferenceService.java
+++ b/src/main/java/swyp12/team9/server/domain/reference/service/ReferenceService.java
@@ -1,6 +1,5 @@
 package swyp12.team9.server.domain.reference.service;
 
-import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -8,8 +7,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import swyp12.team9.server.api.reference.dto.CreateReferenceRequest;
 import swyp12.team9.server.api.reference.dto.ReferenceResponse;
+import swyp12.team9.server.api.reference.dto.ReferenceType;
 import swyp12.team9.server.api.reference.dto.UpdateReferenceRequest;
-import swyp12.team9.server.api.user.dto.response.UserResponse;
 import swyp12.team9.server.domain.reference.exception.ReferenceAccessDeniedException;
 import swyp12.team9.server.domain.reference.exception.ReferenceNotFoundException;
 import swyp12.team9.server.domain.reference.model.Reference;
@@ -67,24 +66,43 @@ public class ReferenceService {
     }
 
     /**
-     * 사용자의 레퍼런스 목록 조회 (커서 페이징)
+     * 레퍼런스 목록 조회 (통합 API - 커서 페이징)
+     *
+     * @param userId 현재 사용자 ID (null 가능)
+     * @param type   조회 타입 (ALL: 전체, PUBLIC: 공개, PRIVATE: 비공개)
+     * @param cursor 페이지 커서
+     * @param size   페이지 크기
      */
-    public PageResponse<ReferenceResponse> getUserReferencesCursor(
+    public PageResponse<ReferenceResponse> getReferences(
+            Long userId, ReferenceType type, String cursor, int size) {
+
+        return switch (type) {
+            case ALL -> getUserReferencesCursor(userId, cursor, size);
+            case PUBLIC -> getPublicReferencesCursor(cursor, size);
+            case PRIVATE -> getNotPublicReferencesCursor(userId, cursor, size);
+        };
+    }
+
+    /**
+     * 사용자의 레퍼런스 목록 조회 (커서 페이징) - 전체
+     */
+    private PageResponse<ReferenceResponse> getUserReferencesCursor(
             Long userId, String cursor, int size) {
+
+        if (userId == null) {
+            throw new ReferenceAccessDeniedException("전체 레퍼런스 조회는 로그인이 필요합니다.");
+        }
 
         if (!userRepository.existsById(userId)) {
             throw new UserNotFoundException("사용자를 찾을 수 없습니다. ID: " + userId);
         }
 
-        // size + 1개를 조회해서 hasNext 판단
         PageRequest pageRequest = PageRequest.of(0, size + 1);
 
         List<Reference> references;
         if (cursor == null) {
-            // 첫 페이지
             references = referenceRepository.findByUserIdOrderByIdDesc(userId, pageRequest);
         } else {
-            // 다음 페이지
             Long cursorId = Long.parseLong(cursor);
             references = referenceRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, cursorId, pageRequest);
         }
@@ -95,8 +113,7 @@ public class ReferenceService {
     /**
      * 공개 레퍼런스 목록 조회 (커서 페이징)
      */
-    public PaginationUtils.Cursor.PageResponse<ReferenceResponse> getPublicReferencesCursor(
-            String cursor, int size) {
+    private PageResponse<ReferenceResponse> getPublicReferencesCursor(String cursor, int size) {
 
         PageRequest pageRequest = PageRequest.of(0, size + 1);
 
@@ -114,8 +131,12 @@ public class ReferenceService {
     /**
      * 비공개 레퍼런스 목록 조회 (커서 페이징)
      */
-    public PaginationUtils.Cursor.PageResponse<ReferenceResponse> getNotPublicReferencesCursor(
+    private PageResponse<ReferenceResponse> getNotPublicReferencesCursor(
             Long userId, String cursor, int size) {
+
+        if (userId == null) {
+            throw new ReferenceAccessDeniedException("비공개 레퍼런스 조회는 로그인이 필요합니다.");
+        }
 
         if (!userRepository.existsById(userId)) {
             throw new UserNotFoundException("사용자를 찾을 수 없습니다. ID: " + userId);
@@ -218,7 +239,7 @@ public class ReferenceService {
      * @param size   페이지 크기
      * @return 모든 사용자의 비공개 레퍼런스 목록
      */
-    public PaginationUtils.Cursor.PageResponse<ReferenceResponse> getAllNotPublicReferencesCursor(
+    public PaginationUtils.Cursor.PageResponse<ReferenceResponse> getAllNotPublicReferences(
             String cursor, int size) {
 
         PageRequest pageRequest = PageRequest.of(0, size + 1);

--- a/src/main/java/swyp12/team9/server/domain/userlink/exception/UserLinkAccessDeniedException.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/exception/UserLinkAccessDeniedException.java
@@ -1,0 +1,15 @@
+package swyp12.team9.server.domain.userlink.exception;
+
+import swyp12.team9.server.global.exception.BusinessException;
+import swyp12.team9.server.global.exception.ErrorCode;
+
+public class UserLinkAccessDeniedException extends BusinessException {
+
+    public UserLinkAccessDeniedException() {
+        super(ErrorCode.USER_LINK_ACCESS_DENIED);
+    }
+
+    public UserLinkAccessDeniedException(String message) {
+        super(ErrorCode.USER_LINK_ACCESS_DENIED, message);
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/userlink/exception/UserLinkDuplicateException.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/exception/UserLinkDuplicateException.java
@@ -1,0 +1,15 @@
+package swyp12.team9.server.domain.userlink.exception;
+
+import swyp12.team9.server.global.exception.BusinessException;
+import swyp12.team9.server.global.exception.ErrorCode;
+
+public class UserLinkDuplicateException extends BusinessException {
+
+    public UserLinkDuplicateException() {
+        super(ErrorCode.USER_LINK_DUPLICATE);
+    }
+
+    public UserLinkDuplicateException(String message) {
+        super(ErrorCode.USER_LINK_DUPLICATE, message);
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/userlink/exception/UserLinkNotFoundException.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/exception/UserLinkNotFoundException.java
@@ -1,0 +1,15 @@
+package swyp12.team9.server.domain.userlink.exception;
+
+import swyp12.team9.server.global.exception.BusinessException;
+import swyp12.team9.server.global.exception.ErrorCode;
+
+public class UserLinkNotFoundException extends BusinessException {
+
+    public UserLinkNotFoundException() {
+        super(ErrorCode.USER_LINK_NOT_FOUND);
+    }
+
+    public UserLinkNotFoundException(String message) {
+        super(ErrorCode.USER_LINK_NOT_FOUND, message);
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/userlink/model/UserLink.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/model/UserLink.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import swyp12.team9.server.domain.link.model.Link;
 import swyp12.team9.server.domain.user.model.User;
+import swyp12.team9.server.domain.userlink.exception.UserLinkAccessDeniedException;
 import swyp12.team9.server.global.common.entity.BaseEntity;
 
 import java.time.LocalDateTime;
@@ -83,5 +84,14 @@ public class UserLink extends BaseEntity {
 
     public void updatePublicStatus(Boolean isPublic) {
         this.isPublic = isPublic;
+    }
+
+    /**
+     * 소유자 검증
+     */
+    public void validateOwner(Long userId) {
+        if (!this.user.getId().equals(userId)) {
+            throw new UserLinkAccessDeniedException("해당 링크에 대한 권한이 없습니다.");
+        }
     }
 }

--- a/src/main/java/swyp12/team9/server/domain/userlink/repository/UserLinkRepository2.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/repository/UserLinkRepository2.java
@@ -1,0 +1,86 @@
+package swyp12.team9.server.domain.userlink.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import swyp12.team9.server.domain.userlink.model.UserLink;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserLinkRepository2 extends JpaRepository<UserLink, Long> {
+
+    // ========== 기본 조회 ==========
+    /**
+     * 사용자 ID로 UserLink 목록 조회
+     */
+    List<UserLink> findByUserId(Long userId);
+
+    /**
+     * 사용자 ID와 링크 ID로 UserLink 조회
+     */
+    Optional<UserLink> findByUserIdAndLinkId(Long userId, Long linkId);
+
+    /**
+     * 사용자가 해당 링크를 이미 저장했는지 확인
+     */
+    boolean existsByUserIdAndLinkId(Long userId, Long linkId);
+
+    /**
+     * 공개 UserLink 목록 조회
+     */
+    List<UserLink> findByIsPublicTrue();
+
+    /**
+     * 사용자 ID와 공개 여부로 조회
+     */
+    List<UserLink> findByUserIdAndIsPublic(Long userId, Boolean isPublic);
+
+    // ========== 커서 페이징: 내 UserLink 전체 ==========
+    /**
+     * 사용자 UserLink 커서 페이징 (첫 페이지)
+     */
+    List<UserLink> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);
+
+    /**
+     * 사용자 UserLink 커서 페이징 (다음 페이지)
+     */
+    List<UserLink> findByUserIdAndIdLessThanOrderByIdDesc(Long userId, Long cursor, Pageable pageable);
+
+    // ========== 커서 페이징: 공개 UserLink ==========
+    /**
+     * 공개 UserLink 커서 페이징 (첫 페이지)
+     */
+    List<UserLink> findByIsPublicTrueOrderByIdDesc(Pageable pageable);
+
+    /**
+     * 공개 UserLink 커서 페이징 (다음 페이지)
+     */
+    List<UserLink> findByIsPublicTrueAndIdLessThanOrderByIdDesc(Long cursor, Pageable pageable);
+
+    // ========== 커서 페이징: 비공개 UserLink ==========
+    /**
+     * 특정 사용자의 비공개 UserLink 커서 페이징 (첫 페이지)
+     */
+    List<UserLink> findByUserIdAndIsPublicFalseOrderByIdDesc(Long userId, Pageable pageable);
+
+    /**
+     * 특정 사용자의 비공개 UserLink 커서 페이징 (다음 페이지)
+     */
+    List<UserLink> findByUserIdAndIsPublicFalseAndIdLessThanOrderByIdDesc(
+            Long userId, Long cursor, Pageable pageable);
+
+    // ========== 읽음 상태별 조회 ==========
+    /**
+     * 사용자의 읽지 않은 UserLink 커서 페이징 (첫 페이지)
+     */
+    List<UserLink> findByUserIdAndStatusOrderByIdDesc(
+            Long userId, swyp12.team9.server.domain.userlink.model.LinkStatus status, Pageable pageable);
+
+    /**
+     * 사용자의 읽지 않은 UserLink 커서 페이징 (다음 페이지)
+     */
+    List<UserLink> findByUserIdAndStatusAndIdLessThanOrderByIdDesc(
+            Long userId, swyp12.team9.server.domain.userlink.model.LinkStatus status, Long cursor, Pageable pageable);
+}

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService2.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService2.java
@@ -53,7 +53,7 @@ public class UserLinkService2 {
 
         // 이미 같은 링크를 저장했는지 확인
         if (userLinkRepository.existsByUserIdAndLinkId(userId, link.getId())) {
-            throw new UserLinkDuplicateException("이미 저장된 링크입니다");
+            throw new UserLinkDuplicateException();
         }
 
         // UserLink 생성

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService2.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService2.java
@@ -15,6 +15,7 @@ import swyp12.team9.server.domain.user.exception.UserNotFoundException;
 import swyp12.team9.server.domain.user.model.User;
 import swyp12.team9.server.domain.user.repository.UserRepository;
 import swyp12.team9.server.domain.userlink.exception.UserLinkAccessDeniedException;
+import swyp12.team9.server.domain.userlink.exception.UserLinkDuplicateException;
 import swyp12.team9.server.domain.userlink.exception.UserLinkNotFoundException;
 import swyp12.team9.server.domain.userlink.model.UserLink;
 import swyp12.team9.server.domain.userlink.repository.UserLinkRepository2;
@@ -52,7 +53,7 @@ public class UserLinkService2 {
 
         // 이미 같은 링크를 저장했는지 확인
         if (userLinkRepository.existsByUserIdAndLinkId(userId, link.getId())) {
-            throw new IllegalArgumentException("이미 저장된 링크입니다.");
+            throw new UserLinkDuplicateException("이미 저장된 링크입니다");
         }
 
         // UserLink 생성

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService2.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService2.java
@@ -1,0 +1,274 @@
+package swyp12.team9.server.domain.userlink.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swyp12.team9.server.api.userlink.dto.CreateUserLinkRequest;
+import swyp12.team9.server.api.userlink.dto.UpdateUserLinkRequest;
+import swyp12.team9.server.api.userlink.dto.UserLinkResponse;
+import swyp12.team9.server.api.userlink.dto.UserLinkType;
+import swyp12.team9.server.domain.link.model.Link;
+import swyp12.team9.server.domain.link.repository.LinkRepository2;
+import swyp12.team9.server.domain.user.exception.UserNotFoundException;
+import swyp12.team9.server.domain.user.model.User;
+import swyp12.team9.server.domain.user.repository.UserRepository;
+import swyp12.team9.server.domain.userlink.exception.UserLinkAccessDeniedException;
+import swyp12.team9.server.domain.userlink.exception.UserLinkNotFoundException;
+import swyp12.team9.server.domain.userlink.model.UserLink;
+import swyp12.team9.server.domain.userlink.repository.UserLinkRepository2;
+import swyp12.team9.server.global.util.PaginationUtils.Cursor.PageResponse;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserLinkService2 {
+
+    private final UserLinkRepository2 userLinkRepository;
+    private final LinkRepository2 linkRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자 링크 생성
+     * - URL로 기존 Link가 있으면 재사용, 없으면 새로 생성
+     */
+    @Transactional
+    public UserLinkResponse createUserLink(Long userId, CreateUserLinkRequest request) {
+        User user = getUserById(userId);
+
+        // URL로 기존 Link 조회 또는 새로 생성
+        Link link = linkRepository.findByUrl(request.url())
+                .orElseGet(() -> {
+                    Link newLink = Link.builder()
+                            .url(request.url())
+                            .build();
+                    return linkRepository.save(newLink);
+                });
+
+        // 이미 같은 링크를 저장했는지 확인
+        if (userLinkRepository.existsByUserIdAndLinkId(userId, link.getId())) {
+            throw new IllegalArgumentException("이미 저장된 링크입니다.");
+        }
+
+        // UserLink 생성
+        UserLink userLink = UserLink.builder()
+                .user(user)
+                .link(link)
+                .why(request.why())
+                .isPublic(request.isPublic())
+                .memo(request.memo())
+                .build();
+
+        UserLink savedUserLink = userLinkRepository.save(userLink);
+
+        log.info("사용자 링크 생성 완료 - userId: {}, userLinkId: {}, url: {}",
+                userId, savedUserLink.getId(), request.url());
+
+        return UserLinkResponse.from(savedUserLink);
+    }
+
+    /**
+     * 사용자 링크 단건 조회
+     * - 공개 링크: 누구나 조회 가능
+     * - 비공개 링크: 소유자만 조회 가능
+     * - 소유자가 조회 시 조회수 증가
+     */
+    @Transactional
+    public UserLinkResponse getUserLink(Long userId, Long userLinkId) {
+        UserLink userLink = getUserLinkById(userLinkId);
+
+        // 소유자가 조회하는 경우 조회수 증가
+        boolean isOwner = userId != null && userLink.getUser().getId().equals(userId);
+        if (isOwner) {
+            userLink.incrementViewCount();
+            log.debug("조회수 증가 - userLinkId: {}, viewCount: {}", userLinkId, userLink.getViewCount());
+        }
+
+        // 공개 링크면 누구나 조회 가능
+        if (userLink.getIsPublic()) {
+            return UserLinkResponse.from(userLink);
+        }
+
+        // 비공개 링크는 소유자만 조회 가능
+        if (userId == null) {
+            throw new UserLinkAccessDeniedException("비공개 링크는 로그인이 필요합니다.");
+        }
+
+        userLink.validateOwner(userId);
+        return UserLinkResponse.from(userLink);
+    }
+
+    /**
+     * 사용자 링크 수정
+     */
+    @Transactional
+    public UserLinkResponse updateUserLink(Long userId, Long userLinkId, UpdateUserLinkRequest request) {
+        UserLink userLink = getUserLinkById(userLinkId);
+
+        // 소유자 검증
+        userLink.validateOwner(userId);
+
+        // 수정 (null이면 기존값 유지)
+        userLink.updateUserLink(
+                request.why() != null ? request.why() : userLink.getWhy(),
+                request.isPublic() != null ? request.isPublic() : userLink.getIsPublic(),
+                request.memo() != null ? request.memo() : userLink.getMemo()
+        );
+
+        log.info("사용자 링크 수정 완료 - userId: {}, userLinkId: {}", userId, userLinkId);
+        return UserLinkResponse.from(userLink);
+    }
+
+    /**
+     * 사용자 링크 삭제
+     */
+    @Transactional
+    public void deleteUserLink(Long userId, Long userLinkId) {
+        UserLink userLink = getUserLinkById(userLinkId);
+
+        // 소유자 검증
+        userLink.validateOwner(userId);
+
+        userLinkRepository.delete(userLink);
+
+        log.info("사용자 링크 삭제 완료 - userId: {}, userLinkId: {}", userId, userLinkId);
+    }
+
+    /**
+     * 사용자 링크 읽음 처리
+     */
+    @Transactional
+    public UserLinkResponse markAsRead(Long userId, Long userLinkId) {
+        UserLink userLink = getUserLinkById(userLinkId);
+
+        // 소유자 검증
+        userLink.validateOwner(userId);
+
+        userLink.markAsRead();
+
+        log.info("사용자 링크 읽음 처리 완료 - userId: {}, userLinkId: {}", userId, userLinkId);
+        return UserLinkResponse.from(userLink);
+    }
+
+    /**
+     * 사용자 링크 목록 조회 (통합 API - 커서 페이징)
+     *
+     * @param userId 현재 사용자 ID (null 가능)
+     * @param type   조회 타입 (ALL: 전체, PUBLIC: 공개, PRIVATE: 비공개)
+     * @param cursor 페이지 커서
+     * @param size   페이지 크기
+     */
+    public PageResponse<UserLinkResponse> getUserLinks(
+            Long userId, UserLinkType type, String cursor, int size) {
+
+        return switch (type) {
+            case ALL -> getMyUserLinksCursor(userId, cursor, size);
+            case PUBLIC -> getPublicUserLinksCursor(cursor, size);
+            case PRIVATE -> getNotPublicUserLinksCursor(userId, cursor, size);
+        };
+    }
+
+    /**
+     * 나의 UserLink 목록 조회 (커서 페이징) - 전체
+     */
+    private PageResponse<UserLinkResponse> getMyUserLinksCursor(Long userId, String cursor, int size) {
+        if (userId == null) {
+            throw new UserLinkAccessDeniedException("전체 링크 조회는 로그인이 필요합니다.");
+        }
+
+        if (!userRepository.existsById(userId)) {
+            throw new UserNotFoundException("사용자를 찾을 수 없습니다. ID: " + userId);
+        }
+
+        PageRequest pageRequest = PageRequest.of(0, size + 1);
+
+        List<UserLink> userLinks;
+        if (cursor == null) {
+            userLinks = userLinkRepository.findByUserIdOrderByIdDesc(userId, pageRequest);
+        } else {
+            Long cursorId = Long.parseLong(cursor);
+            userLinks = userLinkRepository.findByUserIdAndIdLessThanOrderByIdDesc(userId, cursorId, pageRequest);
+        }
+
+        return buildCursorResponse(userLinks, size);
+    }
+
+    /**
+     * 공개 UserLink 목록 조회 (커서 페이징)
+     */
+    private PageResponse<UserLinkResponse> getPublicUserLinksCursor(String cursor, int size) {
+        PageRequest pageRequest = PageRequest.of(0, size + 1);
+
+        List<UserLink> userLinks;
+        if (cursor == null) {
+            userLinks = userLinkRepository.findByIsPublicTrueOrderByIdDesc(pageRequest);
+        } else {
+            Long cursorId = Long.parseLong(cursor);
+            userLinks = userLinkRepository.findByIsPublicTrueAndIdLessThanOrderByIdDesc(cursorId, pageRequest);
+        }
+
+        return buildCursorResponse(userLinks, size);
+    }
+
+    /**
+     * 나의 비공개 UserLink 목록 조회 (커서 페이징)
+     */
+    private PageResponse<UserLinkResponse> getNotPublicUserLinksCursor(Long userId, String cursor, int size) {
+        if (userId == null) {
+            throw new UserLinkAccessDeniedException("비공개 링크 조회는 로그인이 필요합니다.");
+        }
+
+        if (!userRepository.existsById(userId)) {
+            throw new UserNotFoundException("사용자를 찾을 수 없습니다. ID: " + userId);
+        }
+
+        PageRequest pageRequest = PageRequest.of(0, size + 1);
+
+        List<UserLink> userLinks;
+        if (cursor == null) {
+            userLinks = userLinkRepository.findByUserIdAndIsPublicFalseOrderByIdDesc(userId, pageRequest);
+        } else {
+            Long cursorId = Long.parseLong(cursor);
+            userLinks = userLinkRepository.findByUserIdAndIsPublicFalseAndIdLessThanOrderByIdDesc(
+                    userId, cursorId, pageRequest);
+        }
+
+        return buildCursorResponse(userLinks, size);
+    }
+
+    // ========== Helper 메서드 ==========
+
+    /**
+     * 커서 기반 응답 생성 헬퍼 메서드
+     */
+    private PageResponse<UserLinkResponse> buildCursorResponse(List<UserLink> userLinks, int size) {
+        if (userLinks.isEmpty()) {
+            return PageResponse.empty();
+        }
+
+        boolean hasNext = userLinks.size() > size;
+        List<UserLink> content = hasNext ? userLinks.subList(0, size) : userLinks;
+        String nextCursor = hasNext ? String.valueOf(content.get(content.size() - 1).getId()) : null;
+
+        List<UserLinkResponse> responses = content.stream()
+                .map(UserLinkResponse::from)
+                .collect(Collectors.toList());
+
+        return PageResponse.of(responses, nextCursor, hasNext);
+    }
+
+    private User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다. ID: " + userId));
+    }
+
+    private UserLink getUserLinkById(Long userLinkId) {
+        return userLinkRepository.findById(userLinkId)
+                .orElseThrow(() -> new UserLinkNotFoundException("사용자 링크를 찾을 수 없습니다. ID: " + userLinkId));
+    }
+}

--- a/src/main/java/swyp12/team9/server/global/config/SecurityConfig.java
+++ b/src/main/java/swyp12/team9/server/global/config/SecurityConfig.java
@@ -135,6 +135,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/v1/**").hasRole(UserRole.USER.name())
                         .requestMatchers(HttpMethod.GET, "/api/v1/**").hasRole(UserRole.USER.name())
                         .requestMatchers(HttpMethod.PUT, "/api/v1/**").hasRole(UserRole.USER.name())
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/**").hasRole(UserRole.USER.name())
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/**").hasRole(UserRole.USER.name())
 
                         // ========== User API ==========

--- a/src/main/java/swyp12/team9/server/global/config/SecurityConfig.java
+++ b/src/main/java/swyp12/team9/server/global/config/SecurityConfig.java
@@ -110,19 +110,23 @@ public class SecurityConfig {
                         ).permitAll()  // TODO: 인증 구현 후 수정 필요
 
                         // 인증 관련
-                        .requestMatchers("/jwt/exchange", "/jwt/refresh", "/logout").permitAll()
+                        .requestMatchers("/api/v1/jwt/exchange", "/api/v1/jwt/refresh", "/api/v1/auth/logout").permitAll()
                         .requestMatchers(HttpMethod.POST,
-                                "/api/users/exist",
-                                "/api/users/signup",
-                                "/login"
+                                "/api/v1/users/exist",
+                                "/api/v1/users/signup",
+                                "/api/v1/auth/login"
                         ).permitAll()
 
                         // OAuth2 소셜 로그인 관련 경로
-                        .requestMatchers("/oauth2/**", "/login/oauth2/code/**").permitAll()
+                        .requestMatchers("/api/v1/oauth2/**", "/login/oauth2/code/**").permitAll()
 
-                        // 공개 레퍼런스 조회 (익명 허용)
+                        // 레퍼런스 조회 (익명 허용 - Service에서 type별 권한 체크)
                         .requestMatchers(HttpMethod.GET, "/api/v1/references/{referenceId}").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/v1/references/public").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/references").permitAll()
+
+                        // 사용자 링크 조회 (익명 허용 - Service에서 type별 권한 체크)
+                        .requestMatchers(HttpMethod.GET, "/api/v1/user-links/{userLinkId}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/user-links").permitAll()
 
                         // 관리자 전용 API (가장 먼저 체크)
                         .requestMatchers("/api/v1/references/admin/**").hasRole("ADMIN")  // 관리자 전용
@@ -134,9 +138,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.DELETE, "/api/v1/**").hasRole(UserRole.USER.name())
 
                         // ========== User API ==========
-                        .requestMatchers(HttpMethod.GET, "/api/users/*").hasRole(UserRole.USER.name())
-                        .requestMatchers(HttpMethod.PUT, "/api/users/*").hasRole(UserRole.USER.name())
-                        .requestMatchers(HttpMethod.DELETE, "/api/users/*").hasRole(UserRole.USER.name())
+                        .requestMatchers(HttpMethod.GET, "/api/v1/users/*").hasRole(UserRole.USER.name())
+                        .requestMatchers(HttpMethod.PUT, "/api/v1/users/*").hasRole(UserRole.USER.name())
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/users/*").hasRole(UserRole.USER.name())
 
                         // ========== 나머지 모든 요청 ==========
                         .anyRequest().authenticated()
@@ -152,7 +156,7 @@ public class SecurityConfig {
         // 기본 로그아웃 필터 + 커스텀 Refresh 토큰 삭제 핸들러 추가
         http
                 .logout(logout -> logout
-                        .logoutUrl("/logout")
+                        .logoutUrl("/api/v1/auth/logout")
                         .addLogoutHandler(new RefreshTokenLogoutHandler(jwtService))
                         .logoutSuccessHandler((request, response, authentication) -> {
                             response.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/swyp12/team9/server/global/exception/ErrorCode.java
+++ b/src/main/java/swyp12/team9/server/global/exception/ErrorCode.java
@@ -54,6 +54,13 @@ public enum ErrorCode {
     EMPTY_IMAGE_FILE(HttpStatus.BAD_REQUEST, "I007", "이미지 파일이 비어있습니다"),
     INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "I008", "잘못된 이미지 URL입니다"),
 
+    // UserLink
+    USER_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "UL001", "사용자 링크를 찾을 수 없습니다"),
+    USER_LINK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "UL002", "사용자 링크에 접근할 수 없습니다"),
+    USER_LINK_URL_REQUIRED(HttpStatus.BAD_REQUEST, "UL003", "URL은 필수입니다"),
+    USER_LINK_INVALID_URL(HttpStatus.BAD_REQUEST, "UL004", "유효하지 않은 URL 형식입니다"),
+    USER_LINK_WHY_TOO_LONG(HttpStatus.BAD_REQUEST, "UL005", "이유는 500자를 초과할 수 없습니다"),
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/swyp12/team9/server/global/exception/ErrorCode.java
+++ b/src/main/java/swyp12/team9/server/global/exception/ErrorCode.java
@@ -9,57 +9,58 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // Common
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다"),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C002", "허용되지 않은 메서드입니다"),
-    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "C003", "엔티티를 찾을 수 없습니다"),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C004", "서버 오류가 발생했습니다"),
-    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "C005", "잘못된 타입입니다"),
-    HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "C006", "접근이 거부되었습니다"),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "COM001", "잘못된 입력값입니다"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "COM002", "허용되지 않은 메서드입니다"),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "COM003", "엔티티를 찾을 수 없습니다"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COM004", "서버 오류가 발생했습니다"),
+    INVALID_TYPE_VALUE(HttpStatus.BAD_REQUEST, "COM005", "잘못된 타입입니다"),
+    HANDLE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "COM006", "접근이 거부되었습니다"),
 
     // Auth
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다"),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A002", "유효하지 않은 토큰입니다"),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "만료된 토큰입니다"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "ATH001", "인증이 필요합니다"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "ATH002", "유효하지 않은 토큰입니다"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "ATH003", "만료된 토큰입니다"),
 
     // OAuth
-    OAUTH_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "O001", "소셜 로그인에 실패했습니다"),
-    OAUTH_REDIRECT_MISMATCH(HttpStatus.BAD_REQUEST, "O002", "리다이렉트 URI가 일치하지 않습니다"),
+    OAUTH_AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "OTH001", "소셜 로그인에 실패했습니다"),
+    OAUTH_REDIRECT_MISMATCH(HttpStatus.BAD_REQUEST, "OTH002", "리다이렉트 URI가 일치하지 않습니다"),
 
     // User
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다"),
-    EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "U002", "이미 사용 중인 이메일입니다"),
-    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "U003", "잘못된 비밀번호입니다"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USR001", "사용자를 찾을 수 없습니다"),
+    EMAIL_DUPLICATION(HttpStatus.BAD_REQUEST, "USR002", "이미 사용 중인 이메일입니다"),
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USR003", "잘못된 비밀번호입니다"),
 
     // File
-    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드에 실패했습니다"),
-    FILE_SIZE_EXCEED(HttpStatus.BAD_REQUEST, "F002", "파일 크기가 제한을 초과했습니다"),
-    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "F003", "파일을 찾을 수 없습니다"),
-    FILE_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F004", "파일 다운로드에 실패했습니다"),
-    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F005", "파일 삭제에 실패했습니다"),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FIL001", "파일 업로드에 실패했습니다"),
+    FILE_SIZE_EXCEED(HttpStatus.BAD_REQUEST, "FIL002", "파일 크기가 제한을 초과했습니다"),
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FIL003", "파일을 찾을 수 없습니다"),
+    FILE_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FIL004", "파일 다운로드에 실패했습니다"),
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FIL005", "파일 삭제에 실패했습니다"),
 
     // Reference
-    REFERENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "레퍼런스를 찾을 수 없습니다"),
-    REFERENCE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "R002", "레퍼런스에 접근할 수 없습니다."), // 인증은 됐지만 권한이 없음
-    REFERENCE_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, "R003", "제목은 필수입니다"),
-    REFERENCE_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "R004", "제목은 200자를 초과할 수 없습니다"),
-    REFERENCE_DESCRIPTION_TOO_LONG(HttpStatus.BAD_REQUEST, "R005", "설명은 500자를 초과할 수 없습니다"),
+    REFERENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "REF001", "레퍼런스를 찾을 수 없습니다"),
+    REFERENCE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "REF002", "레퍼런스에 접근할 수 없습니다."), // 인증은 됐지만 권한이 없음
+    REFERENCE_TITLE_REQUIRED(HttpStatus.BAD_REQUEST, "REF003", "제목은 필수입니다"),
+    REFERENCE_TITLE_TOO_LONG(HttpStatus.BAD_REQUEST, "REF004", "제목은 200자를 초과할 수 없습니다"),
+    REFERENCE_DESCRIPTION_TOO_LONG(HttpStatus.BAD_REQUEST, "REF005", "설명은 500자를 초과할 수 없습니다"),
 
     // Image
-    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "I001", "이미지 업로드에 실패했습니다"),
-    IMAGE_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "I002", "이미지 다운로드에 실패했습니다"),
-    IMAGE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "I003", "이미지 삭제에 실패했습니다"),
-    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "I004", "이미지를 찾을 수 없습니다"),
-    INVALID_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "I005", "지원하지 않는 이미지 형식입니다"),
-    IMAGE_SIZE_EXCEED(HttpStatus.BAD_REQUEST, "I006", "이미지 크기가 제한을 초과했습니다"),
-    EMPTY_IMAGE_FILE(HttpStatus.BAD_REQUEST, "I007", "이미지 파일이 비어있습니다"),
-    INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "I008", "잘못된 이미지 URL입니다"),
+    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMG001", "이미지 업로드에 실패했습니다"),
+    IMAGE_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMG002", "이미지 다운로드에 실패했습니다"),
+    IMAGE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMG003", "이미지 삭제에 실패했습니다"),
+    IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "IMG004", "이미지를 찾을 수 없습니다"),
+    INVALID_IMAGE_FORMAT(HttpStatus.BAD_REQUEST, "IMG005", "지원하지 않는 이미지 형식입니다"),
+    IMAGE_SIZE_EXCEED(HttpStatus.BAD_REQUEST, "IMG006", "이미지 크기가 제한을 초과했습니다"),
+    EMPTY_IMAGE_FILE(HttpStatus.BAD_REQUEST, "IMG007", "이미지 파일이 비어있습니다"),
+    INVALID_IMAGE_URL(HttpStatus.BAD_REQUEST, "IMG008", "잘못된 이미지 URL입니다"),
 
     // UserLink
-    USER_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "UL001", "사용자 링크를 찾을 수 없습니다"),
-    USER_LINK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "UL002", "사용자 링크에 접근할 수 없습니다"),
-    USER_LINK_URL_REQUIRED(HttpStatus.BAD_REQUEST, "UL003", "URL은 필수입니다"),
-    USER_LINK_INVALID_URL(HttpStatus.BAD_REQUEST, "UL004", "유효하지 않은 URL 형식입니다"),
-    USER_LINK_WHY_TOO_LONG(HttpStatus.BAD_REQUEST, "UL005", "이유는 500자를 초과할 수 없습니다"),
+    USER_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "ULK001", "사용자 링크를 찾을 수 없습니다"),
+    USER_LINK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ULK002", "사용자 링크에 접근할 수 없습니다"),
+    USER_LINK_URL_REQUIRED(HttpStatus.BAD_REQUEST, "ULK003", "URL은 필수입니다"),
+    USER_LINK_INVALID_URL(HttpStatus.BAD_REQUEST, "ULK004", "유효하지 않은 URL 형식입니다"),
+    USER_LINK_WHY_TOO_LONG(HttpStatus.BAD_REQUEST, "ULK005", "이유는 500자를 초과할 수 없습니다"),
+    USER_LINK_DUPLICATE(HttpStatus.CONFLICT, "ULK006", "이미 저장된 링크입니다"),
 
     ;
 

--- a/src/main/java/swyp12/team9/server/global/filter/LoginFilter.java
+++ b/src/main/java/swyp12/team9/server/global/filter/LoginFilter.java
@@ -31,7 +31,7 @@ public class LoginFilter extends AbstractAuthenticationProcessingFilter {
     public static final String SPRING_SECURITY_FORM_PASSWORD_KEY = "password";
 
     private static final RequestMatcher DEFAULT_ANT_PATH_REQUEST_MATCHER = PathPatternRequestMatcher.withDefaults()
-            .matcher(HttpMethod.POST, "/login"); // 로그인
+            .matcher(HttpMethod.POST, "/api/v1/auth/login"); // 로그인
 
     private String usernameParameter = SPRING_SECURITY_FORM_USERNAME_KEY;
 


### PR DESCRIPTION
## 📌 Issues Number
<!--
이 PR과 관련된 이슈 번호를 적어주세요.
예: closes #123, resolves #45
(자동으로 해당 이슈를 닫을 수 있습니다)
-->
closes #24 

## 📚 Summary
<!--
변경 사항의 요약과 배경을 작성해주세요.
왜 이 변경이 필요한지, 어떤 문제를 해결하는지, 주요 변경 내용을 간략히 기술합니다.
-->
  **사용자 링크(UserLink) CRUD 기능을 구현하고, 기존 Reference API와 함께 API 엔드포인트를 /api/v1로 통일했습니다.**                                                         
                                                                                                                                                                         
  **주요 변경 내용:**                                                                                                                                                        
  - UserLink 생성/조회/수정/삭제 API 구현                                                                                                                                
  - URL 입력 방식으로 Link 자동 생성/재사용 로직 추가                                                                                                                    
  - Reference/UserLink 목록 조회 API 통합 (?type=ALL|PUBLIC|PRIVATE)                                                                                                     
  - 부분 수정 API를 PUT → PATCH로 변경                                                                                                                                   
  - 전체 API 엔드포인트 /api/v1 통일             

## 🧩 As-is
<!--
현재 코드/기능의 문제점이나 개선 전의 동작을 설명해주세요.
예:
- 로그인 실패 시 에러 메시지가 표시되지 않음
- API 응답 속도가 느림
-->
                                                                                                                                                                         
  - UserLink 관련 CRUD API가 없어 링크 저장 기능 사용 불가                                                                                                               
  - Reference 목록 조회 API가 3개로 분리되어 있음 (/my, /public, /not-public)                                                                                            
  - API 엔드포인트가 일관되지 않음 (/api/recommend, /login, /logout 등)                                                                                                  
  - 부분 수정에 PUT 메서드 사용 (RESTful 의미에 맞지 않음)             

## 🚀 To-be
<!--
변경 후 기대되는 동작이나 개선된 부분을 작성해주세요.
예:
- 로그인 실패 시 에러 메시지 표시됨
- API 응답 속도 30% 향상
-->
                                                                                                                                                    
  - **UserLink CRUD API 사용 가능**                                                                                                                                          
    - POST /api/v1/user-links - 링크 생성                                                                                                                                
    - GET /api/v1/user-links/{id} - 단건 조회                                                                                                                            
    - PATCH /api/v1/user-links/{id} - 부분 수정                                                                                                                          
    - DELETE /api/v1/user-links/{id} - 삭제                                                                                                                              
    - POST /api/v1/user-links/{id}/read - 읽음 처리                                                                                                                      
    - GET /api/v1/user-links?type=ALL|PUBLIC|PRIVATE - 목록 조회 
                                                                                                            
  - **Reference 목록 조회 API 통합**                                                                                                                                         
    - GET /api/v1/references?type=ALL|PUBLIC|PRIVATE    
                                                                                                                     
  - **전체 API 엔드포인트 /api/v1로 통일**                                                                                                                                   
    - /api/v1/auth/login, /api/v1/auth/logout                                                                                                                            
    - /api/v1/jwt/exchange, /api/v1/jwt/refresh                                                                                                                          
    - /api/v1/recommendations                              
                                                                                                                
  - **부분 수정 API PATCH 메서드로 변경 (RESTful 규약 준수)**                      

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  - 사용자 링크 관리 기능 추가 (생성, 조회, 수정, 삭제, 읽음 표시)
  - 참고 자료 필터링 조회 기능 추가 (전체, 공개, 비공개)

* **API 변경**
  - 모든 API 엔드포인트에 `/api/v1` 버전 접두사 적용
  - 참고 자료 및 사용자 링크 조회 통합 (유형 기반 필터링)
  - 인증 엔드포인트 경로 업데이트 (`/auth/login`, `/auth/logout`)
  - HTTP 메서드 업데이트 (참고 자료 수정: PATCH 방식)

* **오류 처리 개선**
  - 사용자 링크 관련 새로운 오류 코드 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->