### PR TITLE
feat: 탐색 고정 카테고리 테이블/연관 구조 추가

### DIFF
--- a/src/main/java/swyp12/team9/server/domain/category/model/Category.java
+++ b/src/main/java/swyp12/team9/server/domain/category/model/Category.java
@@ -1,0 +1,30 @@
+package swyp12.team9.server.domain.category.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import swyp12.team9.server.global.common.entity.BaseEntity;
+
+/**
+ * 고정 카테고리 (탐색 탭용)
+ * - 경제/시사, 뷰티/패션, 요리/식품, 운동/건강, 인문/지식, 직장/자기개발, 홈/리빙
+ */
+@Entity
+@Table(name = "categories")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category extends BaseEntity {
+
+    @Id
+    @Column(name = "category_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 50, unique = true)
+    private String name;
+
+    @Builder
+    public Category(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/category/model/CategoryLink.java
+++ b/src/main/java/swyp12/team9/server/domain/category/model/CategoryLink.java
@@ -1,0 +1,36 @@
+package swyp12.team9.server.domain.category.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import swyp12.team9.server.domain.link.model.Link;
+import swyp12.team9.server.global.common.entity.BaseEntity;
+
+/**
+ * 카테고리-링크 연관 테이블 (N:M 관계)
+ */
+@Entity
+@Table(name = "category_links")
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CategoryLink extends BaseEntity {
+
+    @Id
+    @Column(name = "category_link_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "link_id", nullable = false)
+    private Link link;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    @Builder
+    public CategoryLink(Link link, Category category) {
+        this.link = link;
+        this.category = category;
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/category/repository/CategoryLinkRepository.java
+++ b/src/main/java/swyp12/team9/server/domain/category/repository/CategoryLinkRepository.java
@@ -1,0 +1,50 @@
+package swyp12.team9.server.domain.category.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import swyp12.team9.server.domain.category.model.Category;
+import swyp12.team9.server.domain.category.model.CategoryLink;
+import swyp12.team9.server.domain.link.model.Link;
+
+import java.util.List;
+
+@Repository
+public interface CategoryLinkRepository extends JpaRepository<CategoryLink, Long> {
+
+    /**
+     * 특정 링크의 카테고리 목록 조회
+     */
+    List<CategoryLink> findByLink(Link link);
+
+    /**
+     * 특정 링크의 카테고리 ID 목록으로 조회
+     */
+    List<CategoryLink> findByLinkId(Long linkId);
+
+    /**
+     * 특정 카테고리에 속한 공개 링크 목록 조회 (커서 페이징 - 첫 페이지)
+     */
+    List<CategoryLink> findByCategoryAndLink_IsPublicTrueOrderByLink_IdDesc(Category category, Pageable pageable);
+
+    /**
+     * 특정 카테고리에 속한 공개 링크 목록 조회 (커서 페이징 - 다음 페이지)
+     */
+    List<CategoryLink> findByCategoryAndLink_IsPublicTrueAndLink_IdLessThanOrderByLink_IdDesc(
+            Category category, Long cursor, Pageable pageable);
+
+    /**
+     * 링크와 카테고리로 존재 여부 확인
+     */
+    boolean existsByLinkAndCategory(Link link, Category category);
+
+    /**
+     * 특정 링크의 카테고리 연결 삭제
+     */
+    void deleteByLink(Link link);
+
+    /**
+     * 특정 링크와 카테고리 연결 삭제
+     */
+    void deleteByLinkAndCategory(Link link, Category category);
+}

--- a/src/main/java/swyp12/team9/server/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/swyp12/team9/server/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,15 @@
+package swyp12.team9.server.domain.category.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import swyp12.team9.server.domain.category.model.Category;
+
+import java.util.Optional;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    Optional<Category> findByName(String name);
+
+    boolean existsByName(String name);
+}


### PR DESCRIPTION
📌 Issues Number
closes feat: 탐색 고정 카테고리 테이블/연관 구조 추가 #33

📚 Summary
탐색 탭의 고정 카테고리를 DB 테이블로 분리하고, 링크와의 N:M 연관 구조를 추가했습니다.

🧩 As-is
- Enum 기반 고정 카테고리로 확장/관리 한계 존재
- 탐색 카테고리와 링크의 관계가 명확히 분리되지 않음

🚀 To-be
- Category/CategoryLink 테이블 기반으로 탐색 카테고리 관리
- 카테고리 기준 탐색 조회 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 링크를 카테고리로 분류하고 관리할 수 있는 카테고리 기능이 추가되었습니다.
  * 각 카테고리별로 공개된 링크를 조회 및 검색할 수 있는 기능이 제공됩니다.
  * 카테고리와 링크 간의 관계를 효율적으로 관리할 수 있도록 지원합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->