### PR TITLE
feat: UserLink API 개선 및 관련 버그 수정

### DIFF
--- a/src/main/java/swyp12/team9/server/api/auth/AuthController.java
+++ b/src/main/java/swyp12/team9/server/api/auth/AuthController.java
@@ -5,7 +5,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import swyp12.team9.server.global.annotation.ApiSpec;
 import swyp12.team9.server.global.exception.ErrorCode;
 
@@ -34,7 +39,7 @@ public class AuthController {
 
     @Operation(summary = "로그아웃", description = "Refresh 토큰을 무효화하여 로그아웃 처리")
     @ApiSpec(
-            status = HttpStatus.OK,
+            status = HttpStatus.NO_CONTENT,
             errors = {
                     ErrorCode.INVALID_TOKEN
             }
@@ -49,14 +54,14 @@ public class AuthController {
             summary = "소셜 로그인",
             description = """
                     소셜 로그인 페이지로 리다이렉트합니다.
-
+                    
                     **지원 provider:** naver, google, kakao
-
+                    
                     **흐름:**
                     1. 이 URL로 접근하면 소셜 로그인 페이지로 리다이렉트
                     2. 사용자가 소셜 로그인 완료
                     3. 콜백 URL로 리다이렉트되며 JWT 토큰 발급
-
+                    
                     **예시 URL:**
                     - 네이버: `/api/v1/oauth2/authorization/naver`
                     - 구글: `/api/v1/oauth2/authorization/google`

--- a/src/main/java/swyp12/team9/server/api/userlink/UserLinkApi.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/UserLinkApi.java
@@ -128,25 +128,6 @@ public interface UserLinkApi {
             @CurrentUserId Long userId
     );
 
-    @Operation(
-            summary = "링크 게시물 열람(읽음) 처리",
-            description = "링크 게시물을 열람 상태로 변경하고 조회수를 증가시킵니다."
-    )
-    @ApiSpec(
-            status = HttpStatus.OK,
-            errors = {
-                    ErrorCode.UNAUTHORIZED,
-                    ErrorCode.USER_LINK_NOT_FOUND,
-                    ErrorCode.USER_LINK_ACCESS_DENIED
-            }
-    )
-    @PostMapping("/{userLinkId}/read")
-    ApiResponse<UserLinkResponse> markAsRead(
-            @Parameter(description = "사용자 링크 ID", required = true, example = "1")
-            @PathVariable Long userLinkId,
-            @CurrentUserId Long userId
-    );
-
     // 사용자 링크 목록 조회
     @Operation(
             summary = "링크 게시물 목록 조회(전체/카테고리별)",

--- a/src/main/java/swyp12/team9/server/api/userlink/UserLinkApi.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/UserLinkApi.java
@@ -31,7 +31,6 @@ import swyp12.team9.server.global.util.PaginationUtils;
 @Tag(name = "UserLink", description = "사용자 링크 관리 API")
 @RequestMapping("/api/v1/user-links")
 public interface UserLinkApi {
-
     @Operation(
             summary = "링크 게시물 생성",
             description = """
@@ -57,6 +56,7 @@ public interface UserLinkApi {
                     ErrorCode.USER_NOT_FOUND,
                     ErrorCode.REFERENCE_NOT_FOUND,
                     ErrorCode.REFERENCE_TITLE_DUPLICATE,
+                    ErrorCode.REFERENCE_SELECTION_DUPLICATE,
                     ErrorCode.LINK_INVALID_URL,
                     ErrorCode.USER_LINK_DUPLICATE,
                     ErrorCode.LINK_SCRAPING_SERVER_ERROR,
@@ -68,6 +68,7 @@ public interface UserLinkApi {
             @Valid @RequestBody UserLinkCreateRequest request,
             @CurrentUserId Long userId
     );
+
 
     @Operation(
             summary = "링크 게시물 단건 조회",
@@ -89,7 +90,16 @@ public interface UserLinkApi {
 
     @Operation(
             summary = "링크 게시물 수정",
-            description = "링크 정보를 부분 수정합니다. 전달된 필드만 수정되며, 소유자만 수정 가능합니다."
+            description = """
+                    링크 정보를 부분 수정합니다. 전달된 필드만 수정되며, 소유자만 수정 가능합니다.
+
+                    **레퍼런스 폴더 변경 방법**
+                    1. 특정 폴더로 이동: `referenceId`에 폴더 ID 전달
+                    2. 미지정 폴더로 이동: `moveToDefault`를 true로 설정
+                    3. 기존 폴더 유지: 둘 다 생략
+
+                    ⚠️ `referenceId`와 `moveToDefault`는 동시에 사용할 수 없습니다.
+                    """
     )
     @ApiSpec(
             status = HttpStatus.OK,
@@ -98,7 +108,8 @@ public interface UserLinkApi {
                     ErrorCode.UNAUTHORIZED,
                     ErrorCode.USER_LINK_NOT_FOUND,
                     ErrorCode.USER_LINK_ACCESS_DENIED,
-                    ErrorCode.REFERENCE_NOT_FOUND
+                    ErrorCode.REFERENCE_NOT_FOUND,
+                    ErrorCode.REFERENCE_SELECTION_DUPLICATE
             }
     )
     @PatchMapping("/{userLinkId}")

--- a/src/main/java/swyp12/team9/server/api/userlink/UserLinkApi.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/UserLinkApi.java
@@ -7,7 +7,14 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import swyp12.team9.server.api.userlink.dto.request.UserLinkCreateRequest;
 import swyp12.team9.server.api.userlink.dto.request.UserLinkUpdateRequest;
 import swyp12.team9.server.api.userlink.dto.response.UserLinkListResponse;
@@ -19,8 +26,7 @@ import swyp12.team9.server.global.exception.ErrorCode;
 import swyp12.team9.server.global.util.PaginationUtils;
 
 /**
- * UserLink API 인터페이스
- * 사용자 링크 관련 API 스펙을 정의합니다.
+ * UserLink API 인터페이스 사용자 링크 관련 API 스펙을 정의합니다.
  */
 @Tag(name = "UserLink", description = "사용자 링크 관리 API")
 @RequestMapping("/api/v1/user-links")
@@ -28,7 +34,20 @@ public interface UserLinkApi {
 
     @Operation(
             summary = "링크 게시물 생성",
-            description = "새로운 링크를 저장합니다. URL로 기존 Link가 있으면 재사용하고, 없으면 새로 생성합니다."
+            description = """
+                    새로운 링크를 저장합니다.
+                    
+                    **레퍼런스 폴더 지정 방법**
+                    1. 기존 폴더 선택: `referenceId`에 폴더 ID 전달
+                    2. 새 폴더 생성: `newReference`에 제목과 색상 코드 전달
+                    3. 미지정: 둘 다 null/빈 값이면 '미지정' 폴더로 자동 분류
+                    
+                    ⚠️ `referenceId`와 `newReference`는 동시에 사용할 수 없습니다.
+                    
+                    **URL 처리:**
+                    - 기존 Link가 있으면 재사용
+                    - 없으면 새로 생성 (추후 스크래핑 적용 예정)
+                    """
     )
     @ApiSpec(
             status = HttpStatus.CREATED,
@@ -37,6 +56,7 @@ public interface UserLinkApi {
                     ErrorCode.UNAUTHORIZED,
                     ErrorCode.USER_NOT_FOUND,
                     ErrorCode.REFERENCE_NOT_FOUND,
+                    ErrorCode.REFERENCE_TITLE_DUPLICATE,
                     ErrorCode.LINK_INVALID_URL,
                     ErrorCode.USER_LINK_DUPLICATE,
                     ErrorCode.LINK_SCRAPING_SERVER_ERROR,

--- a/src/main/java/swyp12/team9/server/api/userlink/UserLinkController.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/UserLinkController.java
@@ -4,7 +4,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import swyp12.team9.server.api.userlink.dto.request.UserLinkCreateRequest;
 import swyp12.team9.server.api.userlink.dto.request.UserLinkUpdateRequest;
 import swyp12.team9.server.api.userlink.dto.response.UserLinkListResponse;
@@ -40,7 +44,7 @@ public class UserLinkController implements UserLinkApi {
             @CurrentUserId(required = false) Long userId) {
 
         UserLinkResponse response = userLinkService.getUserLink(userId, userLinkId);
-        return ApiResponse.ok(response);
+        return ApiResponse.ok(response, "링크를 조회했습니다.");
     }
 
     // 사용자 링크 수정
@@ -62,16 +66,6 @@ public class UserLinkController implements UserLinkApi {
 
         userLinkService.deleteUserLink(userId, userLinkId);
         return ApiResponse.noContent();
-    }
-
-    // 사용자 링크 읽음 처리
-    @Override
-    public ApiResponse<UserLinkResponse> markAsRead(
-            @PathVariable Long userLinkId,
-            @CurrentUserId Long userId) {
-
-        UserLinkResponse response = userLinkService.markAsRead(userId, userLinkId);
-        return ApiResponse.ok(response, "링크를 읽음 처리했습니다.");
     }
 
     // 사용자 링크 목록 조회 (레퍼런스별)

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/request/NewReferenceRequest.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/request/NewReferenceRequest.java
@@ -1,0 +1,31 @@
+package swyp12.team9.server.api.userlink.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 링크 생성 시 새 레퍼런스 폴더를 함께 생성하기 위한 요청 객체
+ */
+@Schema(description = "새 레퍼런스 폴더 생성 요청 (링크 생성 시 함께 사용)")
+public record NewReferenceRequest(
+
+        @Schema(
+                description = "레퍼런스 폴더 제목",
+                example = "개발 공부",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotBlank(message = "레퍼런스 제목은 필수입니다.")
+        @Size(max = 50, message = "레퍼런스 제목은 50자를 초과할 수 없습니다.")
+        String title,
+
+        @Schema(
+                description = "레퍼런스 폴더 색상 코드 (HEX 형식)",
+                example = "#FF5733",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        @Pattern(regexp = "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$", message = "유효한 HEX 색상 코드 형식이어야 합니다.")
+        String colorCode
+) {
+}

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/request/UserLinkCreateRequest.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/request/UserLinkCreateRequest.java
@@ -1,11 +1,10 @@
 package swyp12.team9.server.api.userlink.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.URL;
-
-import java.util.List;
 
 @Schema(description = "사용자 링크 생성 요청 객체")
 public record UserLinkCreateRequest(
@@ -28,17 +27,29 @@ public record UserLinkCreateRequest(
         String url,
 
         @Schema(
-                description = "레퍼런스 폴더 ID 목록 (null 또는 빈 배열이면 미지정 폴더로 자동 분류)",
-                example = "[1, 2, 3]",
+                description = "레퍼런스 폴더 ID (기존 폴더 선택 시 사용, newReference와 상호 배타적)",
+                example = "1",
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED
         )
-        List<Long> referenceIds,
+        Long referenceId,
 
         @Schema(
                 description = "메모",
                 example = "핵심 내용: 경제 패턴에 대한 설명",
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED
         )
-        String memo
+        String memo,
+
+        @Schema(
+                description = """
+                        새 레퍼런스 폴더 생성 정보 (선택)
+                        - referenceId와 상호 배타적: 둘 중 하나만 사용 가능
+                        - 새 폴더 생성 시 이 필드에 제목과 색상 코드 전달
+                        - referenceId와 newReference 모두 null/빈 값이면: 미지정 폴더로 자동 분류
+                        """,
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        @Valid
+        NewReferenceRequest newReference
 ) {
 }

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/request/UserLinkUpdateRequest.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/request/UserLinkUpdateRequest.java
@@ -22,7 +22,7 @@ public record UserLinkUpdateRequest(
         String memo,
 
         @Schema(
-                description = "레퍼런스 폴더 ID (생략 시 기존값 유지, 빈 문자열이면 미지정 폴더로 이동)",
+                description = "레퍼런스 폴더 ID (생략 시 기존값 유지, null이면 미지정 폴더로 이동)",
                 example = "1",
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED
         )

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/request/UserLinkUpdateRequest.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/request/UserLinkUpdateRequest.java
@@ -3,8 +3,6 @@ package swyp12.team9.server.api.userlink.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 
-import java.util.List;
-
 @Schema(description = "사용자 링크 수정 요청 객체")
 public record UserLinkUpdateRequest(
 
@@ -24,10 +22,10 @@ public record UserLinkUpdateRequest(
         String memo,
 
         @Schema(
-                description = "레퍼런스 폴더 ID 목록 (생략 시 기존값 유지, null 또는 빈 배열이면 미지정 폴더로 이동)",
-                example = "[1, 2, 3]",
+                description = "레퍼런스 폴더 ID (생략 시 기존값 유지, 빈 문자열이면 미지정 폴더로 이동)",
+                example = "1",
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED
         )
-        List<Long> referenceIds
+        Long referenceId
 ) {
 }

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/request/UserLinkUpdateRequest.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/request/UserLinkUpdateRequest.java
@@ -22,10 +22,17 @@ public record UserLinkUpdateRequest(
         String memo,
 
         @Schema(
-                description = "레퍼런스 폴더 ID (생략 시 기존값 유지, null이면 미지정 폴더로 이동)",
+                description = "레퍼런스 폴더 ID (생략 시 기존값 유지, moveToDefault와 상호 배타적)",
                 example = "1",
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED
         )
-        Long referenceId
+        Long referenceId,
+
+        @Schema(
+                description = "미지정 폴더로 이동 여부 (true면 미지정 폴더로 이동, referenceId와 상호 배타적)",
+                example = "false",
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        Boolean moveToDefault
 ) {
 }

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/response/UserLinkResponse.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/response/UserLinkResponse.java
@@ -13,8 +13,8 @@ public record UserLinkResponse(
         @Schema(description = "사용자 링크 ID", example = "1")
         Long id,
 
-        @Schema(description = "레퍼런스 정보 목록")
-        ReferenceInfo referenceInfo,
+        @Schema(description = "레퍼런스 정보")
+        ReferenceInfo reference,
 
         @Schema(description = "링크 제목", example = "디자인 패턴 가이드")
         String title,
@@ -46,11 +46,11 @@ public record UserLinkResponse(
      */
     public static UserLinkResponse from(UserLink userLink, Reference reference) {
 
-        ReferenceInfo referenceInfo = ReferenceInfo.from(reference);
+        ReferenceInfo newReference = ReferenceInfo.from(reference);
 
         return UserLinkResponse.builder()
                 .id(userLink.getId())
-                .referenceInfo(referenceInfo)
+                .reference(newReference)
                 .title(userLink.getLink().getTitle())
                 .url(userLink.getLink().getUrl())
                 .aiSummary(userLink.getLink().getAiSummary())
@@ -69,7 +69,7 @@ public record UserLinkResponse(
     public static UserLinkResponse from(UserLink userLink) {
         return UserLinkResponse.builder()
                 .id(userLink.getId())
-                .referenceInfo(null)
+                .reference(null)
                 .title(userLink.getLink().getTitle())
                 .url(userLink.getLink().getUrl())
                 .aiSummary(userLink.getLink().getAiSummary())

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/response/UserLinkResponse.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/response/UserLinkResponse.java
@@ -6,9 +6,6 @@ import swyp12.team9.server.domain.reference.model.Reference;
 import swyp12.team9.server.domain.userlink.model.LinkStatus;
 import swyp12.team9.server.domain.userlink.model.UserLink;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Builder
 @Schema(description = "사용자 링크 응답 객체")
 public record UserLinkResponse(
@@ -17,7 +14,7 @@ public record UserLinkResponse(
         Long id,
 
         @Schema(description = "레퍼런스 정보 목록")
-        List<ReferenceInfo> references,
+        ReferenceInfo referenceInfo,
 
         @Schema(description = "링크 제목", example = "디자인 패턴 가이드")
         String title,
@@ -43,17 +40,17 @@ public record UserLinkResponse(
 
     /**
      * UserLink 엔티티와 Reference 목록으로부터 응답 생성
-     * @param userLink UserLink 엔티티
-     * @param references Reference 목록
+     *
+     * @param userLink  UserLink 엔티티
+     * @param reference Reference 엔티티
      */
-    public static UserLinkResponse from(UserLink userLink, List<Reference> references) {
-        List<ReferenceInfo> referenceInfos = references.stream()
-                .map(ReferenceInfo::from)
-                .collect(Collectors.toList());
+    public static UserLinkResponse from(UserLink userLink, Reference reference) {
+
+        ReferenceInfo referenceInfo = ReferenceInfo.from(reference);
 
         return UserLinkResponse.builder()
                 .id(userLink.getId())
-                .references(referenceInfos)
+                .referenceInfo(referenceInfo)
                 .title(userLink.getLink().getTitle())
                 .url(userLink.getLink().getUrl())
                 .aiSummary(userLink.getLink().getAiSummary())
@@ -66,12 +63,13 @@ public record UserLinkResponse(
 
     /**
      * UserLink 엔티티로부터 응답 생성 (Reference 없음)
+     *
      * @param userLink UserLink 엔티티
      */
     public static UserLinkResponse from(UserLink userLink) {
         return UserLinkResponse.builder()
                 .id(userLink.getId())
-                .references(List.of())
+                .referenceInfo(null)
                 .title(userLink.getLink().getTitle())
                 .url(userLink.getLink().getUrl())
                 .aiSummary(userLink.getLink().getAiSummary())

--- a/src/main/java/swyp12/team9/server/domain/image/exception/ImageDeleteFailedException.java
+++ b/src/main/java/swyp12/team9/server/domain/image/exception/ImageDeleteFailedException.java
@@ -9,7 +9,4 @@ public class ImageDeleteFailedException extends BusinessException {
         super(ErrorCode.IMAGE_DELETE_FAILED);
     }
 
-    public ImageDeleteFailedException(String message) {
-        super(ErrorCode.IMAGE_DELETE_FAILED, message);
-    }
 }

--- a/src/main/java/swyp12/team9/server/domain/image/exception/ImageNotFoundException.java
+++ b/src/main/java/swyp12/team9/server/domain/image/exception/ImageNotFoundException.java
@@ -9,7 +9,4 @@ public class ImageNotFoundException extends BusinessException {
         super(ErrorCode.IMAGE_NOT_FOUND);
     }
 
-    public ImageNotFoundException(String message) {
-        super(ErrorCode.IMAGE_NOT_FOUND, message);
-    }
 }

--- a/src/main/java/swyp12/team9/server/domain/image/exception/ImageUploadFailedException.java
+++ b/src/main/java/swyp12/team9/server/domain/image/exception/ImageUploadFailedException.java
@@ -9,7 +9,4 @@ public class ImageUploadFailedException extends BusinessException {
         super(ErrorCode.IMAGE_UPLOAD_FAILED);
     }
 
-    public ImageUploadFailedException(String message) {
-        super(ErrorCode.IMAGE_UPLOAD_FAILED, message);
-    }
 }

--- a/src/main/java/swyp12/team9/server/domain/reference/exception/ReferenceAccessDeniedException.java
+++ b/src/main/java/swyp12/team9/server/domain/reference/exception/ReferenceAccessDeniedException.java
@@ -5,8 +5,8 @@ import swyp12.team9.server.global.exception.ErrorCode;
 
 public class ReferenceAccessDeniedException extends BusinessException {
 
-    public ReferenceAccessDeniedException() { super(ErrorCode.REFERENCE_ACCESS_DENIED);}
-
-    public ReferenceAccessDeniedException(String message) { super(ErrorCode.REFERENCE_ACCESS_DENIED, message); }
+    public ReferenceAccessDeniedException() {
+        super(ErrorCode.REFERENCE_ACCESS_DENIED);
+    }
 
 }

--- a/src/main/java/swyp12/team9/server/domain/reference/exception/ReferenceNotFoundException.java
+++ b/src/main/java/swyp12/team9/server/domain/reference/exception/ReferenceNotFoundException.java
@@ -5,12 +5,8 @@ import swyp12.team9.server.global.exception.ErrorCode;
 
 public class ReferenceNotFoundException extends BusinessException {
 
-
     public ReferenceNotFoundException() {
         super(ErrorCode.REFERENCE_NOT_FOUND);
     }
 
-    public ReferenceNotFoundException(String message) {
-        super(ErrorCode.REFERENCE_NOT_FOUND, message);
-    }
 }

--- a/src/main/java/swyp12/team9/server/domain/reference/exception/ReferenceTitleDuplicateException.java
+++ b/src/main/java/swyp12/team9/server/domain/reference/exception/ReferenceTitleDuplicateException.java
@@ -9,7 +9,4 @@ public class ReferenceTitleDuplicateException extends BusinessException {
         super(ErrorCode.REFERENCE_TITLE_DUPLICATE);
     }
 
-    public ReferenceTitleDuplicateException(String message) {
-        super(ErrorCode.REFERENCE_TITLE_DUPLICATE, message);
-    }
 }

--- a/src/main/java/swyp12/team9/server/domain/reference/exception/ReferenceValidationException.java
+++ b/src/main/java/swyp12/team9/server/domain/reference/exception/ReferenceValidationException.java
@@ -4,11 +4,9 @@ import swyp12.team9.server.global.exception.BusinessException;
 import swyp12.team9.server.global.exception.ErrorCode;
 
 public class ReferenceValidationException extends BusinessException {
+
     public ReferenceValidationException(ErrorCode errorCode) {
         super(errorCode);
     }
 
-    public ReferenceValidationException(ErrorCode errorCode, String message) {
-        super(errorCode, message);
-    }
 }

--- a/src/main/java/swyp12/team9/server/domain/reference/service/ReferenceService.java
+++ b/src/main/java/swyp12/team9/server/domain/reference/service/ReferenceService.java
@@ -1,5 +1,6 @@
 package swyp12.team9.server.domain.reference.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,8 +13,8 @@ import swyp12.team9.server.api.reference.dto.request.ReferenceUpdateRequest;
 import swyp12.team9.server.api.reference.dto.response.ReferenceListResponse;
 import swyp12.team9.server.api.reference.dto.response.ReferenceResponse;
 import swyp12.team9.server.domain.auth.exception.UnauthorizedException;
-import swyp12.team9.server.domain.reference.exception.ReferenceTitleDuplicateException;
 import swyp12.team9.server.domain.reference.exception.ReferenceNotFoundException;
+import swyp12.team9.server.domain.reference.exception.ReferenceTitleDuplicateException;
 import swyp12.team9.server.domain.reference.model.Reference;
 import swyp12.team9.server.domain.reference.repository.ReferenceRepository;
 import swyp12.team9.server.domain.user.exception.UserNotFoundException;
@@ -21,8 +22,6 @@ import swyp12.team9.server.domain.user.model.User;
 import swyp12.team9.server.domain.user.repository.UserRepository;
 import swyp12.team9.server.domain.userlink.repository.UserLinkRepository;
 import swyp12.team9.server.global.util.PaginationUtils.Cursor.PageResponse;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -67,9 +66,7 @@ public class ReferenceService {
     }
 
     /**
-     * 레퍼런스 단건 조회
-     * - 공개 레퍼런스: 누구나 조회 가능
-     * - 비공개 레퍼런스: 소유자만 조회 가능
+     * 레퍼런스 단건 조회 - 공개 레퍼런스: 누구나 조회 가능 - 비공개 레퍼런스: 소유자만 조회 가능
      */
     public ReferenceResponse getReference(Long userId, Long referenceId) {
 
@@ -90,11 +87,11 @@ public class ReferenceService {
      * @param cursor 페이지 커서
      * @param size   페이지 크기
      */
-  public PageResponse<ReferenceListResponse> getReferences(Long userId,
-            ReferenceType type,
-            ReferenceSortType sortBy,
-            String cursor,
-            int size
+    public PageResponse<ReferenceListResponse> getReferences(Long userId,
+                                                             ReferenceType type,
+                                                             ReferenceSortType sortBy,
+                                                             String cursor,
+                                                             int size
     ) {
         ReferenceCursor referenceCursor = ReferenceCursor.from(cursor, sortBy);
 
@@ -149,8 +146,7 @@ public class ReferenceService {
     }
 
     /**
-     * 레퍼런스 삭제
-     * - 기본 미지정 폴더는 삭제 불가
+     * 레퍼런스 삭제 - 기본 미지정 폴더는 삭제 불가
      */
     @Transactional
     public void deleteReference(Long userId, Long referenceId) {
@@ -184,12 +180,10 @@ public class ReferenceService {
     }
 
     /**
-     * 레퍼런스 생성 (엔티티 반환)
-     * - 다른 서비스에서 레퍼런스 생성 후 엔티티가 필요할 때 사용
-     * - 예: UserLink 생성 시 새 레퍼런스 폴더를 함께 생성하는 경우
+     * 레퍼런스 생성 (엔티티 반환) - 다른 서비스에서 레퍼런스 생성 후 엔티티가 필요할 때 사용 - 예: UserLink 생성 시 새 레퍼런스 폴더를 함께 생성하는 경우
      *
-     * @param userId 사용자 ID
-     * @param title 레퍼런스 제목
+     * @param userId    사용자 ID
+     * @param title     레퍼런스 제목
      * @param colorCode 색상 코드 (null 가능)
      * @return 생성된 Reference 엔티티
      */
@@ -229,7 +223,7 @@ public class ReferenceService {
     // 레퍼런스 조회 메서드
     private Reference getReferenceById(Long referenceId) {
         return referenceRepository.findById(referenceId)
-                .orElseThrow(() -> new ReferenceNotFoundException("레퍼런스를 찾을 수 없습니다. ID: " + referenceId));
+                .orElseThrow(ReferenceNotFoundException::new);
     }
 
     private void validateReferenceAccess(Reference reference, Long userId) {

--- a/src/main/java/swyp12/team9/server/domain/reference/service/ReferenceService.java
+++ b/src/main/java/swyp12/team9/server/domain/reference/service/ReferenceService.java
@@ -183,6 +183,38 @@ public class ReferenceService {
                 });
     }
 
+    /**
+     * 레퍼런스 생성 (엔티티 반환)
+     * - 다른 서비스에서 레퍼런스 생성 후 엔티티가 필요할 때 사용
+     * - 예: UserLink 생성 시 새 레퍼런스 폴더를 함께 생성하는 경우
+     *
+     * @param userId 사용자 ID
+     * @param title 레퍼런스 제목
+     * @param colorCode 색상 코드 (null 가능)
+     * @return 생성된 Reference 엔티티
+     */
+    @Transactional
+    public Reference createReferenceEntity(Long userId, String title, String colorCode) {
+        User user = getUserById(userId);
+
+        validateDuplicateTitle(userId, title);
+
+        Reference reference = Reference.create(
+                user,
+                title,
+                null,  // description은 null로 설정
+                true, // 기본 : 공개
+                colorCode
+        );
+
+        Reference savedReference = referenceRepository.save(reference);
+
+        log.info("레퍼런스 생성 완료 (엔티티 반환) - userId: {}, referenceId: {}, title: {}",
+                userId, savedReference.getId(), title);
+
+        return savedReference;
+    }
+
     // 사용자 조회 메서드
     private User getUserById(Long userId) {
 

--- a/src/main/java/swyp12/team9/server/domain/userlink/exception/ReferenceSelectionDuplicateException.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/exception/ReferenceSelectionDuplicateException.java
@@ -1,0 +1,15 @@
+package swyp12.team9.server.domain.userlink.exception;
+
+import swyp12.team9.server.global.exception.BusinessException;
+import swyp12.team9.server.global.exception.ErrorCode;
+
+public class ReferenceSelectionDuplicateException extends BusinessException {
+
+    public ReferenceSelectionDuplicateException() {
+        super(ErrorCode.REFERENCE_SELECTION_DUPLICATE);
+    }
+
+    public ReferenceSelectionDuplicateException(String message) {
+        super(ErrorCode.REFERENCE_SELECTION_DUPLICATE, message);
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/userlink/exception/ReferenceSelectionDuplicateException.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/exception/ReferenceSelectionDuplicateException.java
@@ -9,7 +9,4 @@ public class ReferenceSelectionDuplicateException extends BusinessException {
         super(ErrorCode.REFERENCE_SELECTION_DUPLICATE);
     }
 
-    public ReferenceSelectionDuplicateException(String message) {
-        super(ErrorCode.REFERENCE_SELECTION_DUPLICATE, message);
-    }
 }

--- a/src/main/java/swyp12/team9/server/domain/userlink/exception/UserLinkAccessDeniedException.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/exception/UserLinkAccessDeniedException.java
@@ -8,8 +8,5 @@ public class UserLinkAccessDeniedException extends BusinessException {
     public UserLinkAccessDeniedException() {
         super(ErrorCode.USER_LINK_ACCESS_DENIED);
     }
-
-    public UserLinkAccessDeniedException(String message) {
-        super(ErrorCode.USER_LINK_ACCESS_DENIED, message);
-    }
+    
 }

--- a/src/main/java/swyp12/team9/server/domain/userlink/exception/UserLinkDuplicateException.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/exception/UserLinkDuplicateException.java
@@ -9,7 +9,4 @@ public class UserLinkDuplicateException extends BusinessException {
         super(ErrorCode.USER_LINK_DUPLICATE);
     }
 
-    public UserLinkDuplicateException(String message) {
-        super(ErrorCode.USER_LINK_DUPLICATE, message);
-    }
 }

--- a/src/main/java/swyp12/team9/server/domain/userlink/exception/UserLinkNotFoundException.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/exception/UserLinkNotFoundException.java
@@ -9,7 +9,4 @@ public class UserLinkNotFoundException extends BusinessException {
         super(ErrorCode.USER_LINK_NOT_FOUND);
     }
 
-    public UserLinkNotFoundException(String message) {
-        super(ErrorCode.USER_LINK_NOT_FOUND, message);
-    }
 }

--- a/src/main/java/swyp12/team9/server/domain/userlink/model/UserLink.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/model/UserLink.java
@@ -1,13 +1,26 @@
 package swyp12.team9.server.domain.userlink.model;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import swyp12.team9.server.domain.link.model.Link;
 import swyp12.team9.server.domain.user.model.User;
 import swyp12.team9.server.domain.userlink.exception.UserLinkAccessDeniedException;
 import swyp12.team9.server.global.common.entity.BaseEntity;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "user_links")
@@ -74,11 +87,6 @@ public class UserLink extends BaseEntity {
         }
         this.lastOpenedAt = LocalDateTime.now();
         this.viewCount++;
-    }
-
-    public void incrementViewCount() {
-        this.viewCount++;
-        this.lastOpenedAt = LocalDateTime.now();
     }
 
     public void validateOwner(Long userId) {

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
@@ -133,8 +133,8 @@ public class UserLinkService {
         }
         userLink.validateOwner(userId);
 
-        // 조회수 증가
-        userLink.incrementViewCount();
+        // 읽음 처리(조회수 증가)
+        userLink.markAsRead();
         log.debug("조회수 증가 - userLinkId: {}, viewCount: {}", userLinkId, userLink.getViewCount());
 
         // UserLink에 연결된 Reference 조회 (단일)
@@ -212,28 +212,6 @@ public class UserLinkService {
         log.info("사용자 링크 삭제 완료 - userId: {}, userLinkId: {}", userId, userLinkId);
     }
 
-    /**
-     * 사용자 링크 읽음 처리
-     */
-    @Transactional
-    public UserLinkResponse markAsRead(Long userId, Long userLinkId) {
-        UserLink userLink = getUserLinkById(userLinkId);
-
-        // 소유자 검증
-        userLink.validateOwner(userId);
-
-        userLink.markAsRead();
-
-        // UserLink에 연결된 Reference 조회 (단일)
-        Reference reference = referenceUserLinkRepository.findByUserLinkId(userLinkId).stream()
-                .map(ReferenceUserLink::getReference)
-                .findFirst()
-                .orElse(null);
-
-        log.info("사용자 링크 읽음 처리 완료 - userId: {}, userLinkId: {}", userId, userLinkId);
-
-        return UserLinkResponse.from(userLink, reference);
-    }
 
     /**
      * 사용자 링크 목록 조회 (커서 페이징)

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
@@ -22,6 +22,7 @@ import swyp12.team9.server.domain.referenceuserlink.repository.ReferenceUserLink
 import swyp12.team9.server.domain.user.exception.UserNotFoundException;
 import swyp12.team9.server.domain.user.model.User;
 import swyp12.team9.server.domain.user.repository.UserRepository;
+import swyp12.team9.server.domain.userlink.exception.ReferenceSelectionDuplicateException;
 import swyp12.team9.server.domain.userlink.exception.UserLinkAccessDeniedException;
 import swyp12.team9.server.domain.userlink.exception.UserLinkDuplicateException;
 import swyp12.team9.server.domain.userlink.exception.UserLinkNotFoundException;
@@ -56,7 +57,7 @@ public class UserLinkService {
         boolean hasNewReference = request.newReference() != null && request.newReference().title() != null;
 
         if (hasReferenceId && hasNewReference) {
-            throw new IllegalArgumentException("기존 폴더 선택과 새 폴더 생성은 동시에 사용할 수 없습니다.");
+            throw new ReferenceSelectionDuplicateException("기존 폴더 선택과 새 폴더 생성은 동시에 사용할 수 없습니다.");
         }
 
         // URL로 기존 Link 조회

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
@@ -1,5 +1,7 @@
 package swyp12.team9.server.domain.userlink.service;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -7,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import swyp12.team9.server.api.userlink.dto.request.UserLinkCreateRequest;
 import swyp12.team9.server.api.userlink.dto.request.UserLinkUpdateRequest;
-import swyp12.team9.server.api.userlink.dto.response.ReferenceInfo;
 import swyp12.team9.server.api.userlink.dto.response.UserLinkListResponse;
 import swyp12.team9.server.api.userlink.dto.response.UserLinkResponse;
 import swyp12.team9.server.domain.link.model.Link;
@@ -28,10 +29,6 @@ import swyp12.team9.server.domain.userlink.model.UserLink;
 import swyp12.team9.server.domain.userlink.repository.UserLinkRepository;
 import swyp12.team9.server.global.util.PaginationUtils.Cursor.PageResponse;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -40,22 +37,27 @@ public class UserLinkService {
 
     private final UserLinkRepository userLinkRepository;
     private final LinkRepository linkRepository;
-//    private final LinkService linkService; TODO 박현제: 스크래핑 로직 추가 예정
+    //    private final LinkService linkService; TODO 박현제: 스크래핑 로직 추가 예정
     private final UserRepository userRepository;
     private final ReferenceRepository referenceRepository;
     private final ReferenceUserLinkRepository referenceUserLinkRepository;
     private final ReferenceService referenceService;
 
     /**
-     * 사용자 링크 생성
-     * - 중복 체크를 먼저 수행한 후 Link 생성
-     * - LinkService를 통해 Link 스크래핑 로직 처리
-     * - referenceIds가 null이거나 빈 배열이면 기본 미지정 폴더에 자동 분류
-     * - 여러 Reference에 동시에 속할 수 있음 (N:N 관계)
+     * 사용자 링크 생성 - 중복 체크를 먼저 수행한 후 Link 생성 - LinkService를 통해 Link 스크래핑 로직 처리 - referenceId와 newReference는 상호 배타적 (둘 중
+     * 하나만 선택) - 둘 다 null이면 기본 미지정 폴더에 자동 분류
      */
     @Transactional
     public UserLinkResponse createUserLink(Long userId, UserLinkCreateRequest request) {
         User user = getUserById(userId);
+
+        // referenceId와 newReference 동시 사용 검증
+        boolean hasReferenceId = request.referenceId() != null;
+        boolean hasNewReference = request.newReference() != null && request.newReference().title() != null;
+
+        if (hasReferenceId && hasNewReference) {
+            throw new IllegalArgumentException("기존 폴더 선택과 새 폴더 생성은 동시에 사용할 수 없습니다.");
+        }
 
         // URL로 기존 Link 조회
         Link link = linkRepository.findByUrl(request.url()).orElse(null);
@@ -84,40 +86,42 @@ public class UserLinkService {
 
         UserLink savedUserLink = userLinkRepository.save(userLink);
 
-        // ReferenceUserLink 생성
-        List<Reference> references = new ArrayList<>();
-        if (request.referenceIds() == null || request.referenceIds().isEmpty()) {
-            // referenceIds가 null이거나 빈 배열이면 기본 미지정 폴더에 자동 분류
-            Reference defaultReference = referenceService.getOrCreateDefaultReference(userId);
-            references.add(defaultReference);
+        // ReferenceUserLink 생성 (상호 배타적: 기존 폴더 OR 새 폴더 OR 미지정)
+        Reference reference;
+
+        if (hasReferenceId) {
+            // 1. 기존 레퍼런스 폴더 선택한 경우
+            reference = getReferenceById(request.referenceId());
+            reference.validateOwner(userId);
+        } else if (hasNewReference) {
+            // 2. 새 레퍼런스 폴더 생성 옵션 선택한 경우
+            reference = referenceService.createReferenceEntity(
+                    userId,
+                    request.newReference().title(),
+                    request.newReference().colorCode()
+            );
+            log.info("새 레퍼런스 폴더 생성 - userId: {}, referenceId: {}, title: {}",
+                    userId, reference.getId(), request.newReference().title());
         } else {
-            // referenceIds로 Reference 조회 및 검증
-            for (Long referenceId : request.referenceIds()) {
-                Reference reference = getReferenceById(referenceId);
-                reference.validateOwner(userId); // 소유자 검증
-                references.add(reference);
-            }
+            // 3. 아무것도 선택하지 않은 경우, 기본 미지정 폴더에 자동 분류
+            reference = referenceService.getOrCreateDefaultReference(userId);
         }
 
         // ReferenceUserLink 엔티티 생성 및 저장
-        for (Reference reference : references) {
-            ReferenceUserLink referenceUserLink = ReferenceUserLink.builder()
-                    .reference(reference)
-                    .userLink(savedUserLink)
-                    .build();
-            referenceUserLinkRepository.save(referenceUserLink);
-        }
+        ReferenceUserLink referenceUserLink = ReferenceUserLink.builder()
+                .reference(reference)
+                .userLink(savedUserLink)
+                .build();
+        referenceUserLinkRepository.save(referenceUserLink);
 
-        log.info("사용자 링크 생성 완료 - userId: {}, userLinkId: {}, referenceCount: {}, url: {}",
-                userId, savedUserLink.getId(), references.size(), request.url());
+        log.info("사용자 링크 생성 완료 - userId: {}, userLinkId: {}, referenceId: {}, url: {}",
+                userId, savedUserLink.getId(), reference.getId(), request.url());
 
-        return UserLinkResponse.from(savedUserLink, references);
+        return UserLinkResponse.from(savedUserLink, reference);
     }
 
     /**
-     * 사용자 링크 단건 조회
-     * - 소유자만 조회 가능 (N:N 관계로 공개/비공개 복잡도 증가)
-     * - 소유자가 조회 시 조회수 증가
+     * 사용자 링크 단건 조회 - 소유자만 조회 가능 (N:N 관계로 공개/비공개 복잡도 증가) - 소유자가 조회 시 조회수 증가
      */
     @Transactional
     public UserLinkResponse getUserLink(Long userId, Long userLinkId) {
@@ -133,18 +137,17 @@ public class UserLinkService {
         userLink.incrementViewCount();
         log.debug("조회수 증가 - userLinkId: {}, viewCount: {}", userLinkId, userLink.getViewCount());
 
-        // UserLink에 연결된 Reference 목록 조회
-        List<ReferenceUserLink> referenceUserLinks = referenceUserLinkRepository.findByUserLinkId(userLinkId);
-        List<Reference> references = referenceUserLinks.stream()
+        // UserLink에 연결된 Reference 조회 (단일)
+        Reference reference = referenceUserLinkRepository.findByUserLinkId(userLinkId).stream()
                 .map(ReferenceUserLink::getReference)
-                .collect(Collectors.toList());
+                .findFirst()
+                .orElse(null);
 
-        return UserLinkResponse.from(userLink, references);
+        return UserLinkResponse.from(userLink, reference);
     }
 
     /**
-     * 사용자 링크 수정
-     * - referenceIds가 제공되면 기존 ReferenceUserLink를 모두 삭제하고 새로 생성
+     * 사용자 링크 수정 - referenceId가 제공되면 기존 ReferenceUserLink를 삭제하고 새로 생성
      */
     @Transactional
     public UserLinkResponse updateUserLink(Long userId, Long userLinkId, UserLinkUpdateRequest request) {
@@ -159,54 +162,39 @@ public class UserLinkService {
                 request.memo() != null ? request.memo() : userLink.getMemo()
         );
 
-        // Reference 처리 (referenceIds가 제공된 경우에만)
-        List<Reference> references;
-        if (request.referenceIds() != null) {
-            // 기존 ReferenceUserLink 모두 삭제
+        // Reference 처리 (referenceId가 제공된 경우에만)
+        Reference reference;
+        if (request.referenceId() != null) {
+            // 기존 ReferenceUserLink 삭제
             referenceUserLinkRepository.deleteByUserLinkId(userLinkId);
 
-            // 새로운 ReferenceUserLink 생성
-            List<Reference> newReferences = new ArrayList<>();
-            if (request.referenceIds().isEmpty()) {
-                // 빈 배열이면 기본 미지정 폴더로 이동
-                Reference defaultReference = referenceService.getOrCreateDefaultReference(userId);
-                newReferences.add(defaultReference);
-            } else {
-                // referenceIds로 Reference 조회 및 검증
-                for (Long referenceId : request.referenceIds()) {
-                    Reference reference = getReferenceById(referenceId);
-                    reference.validateOwner(userId);
-                    newReferences.add(reference);
-                }
-            }
+            // 새로운 Reference 결정
+            // referenceId로 Reference 조회 및 검증
+            reference = getReferenceById(request.referenceId());
+            reference.validateOwner(userId);
 
             // ReferenceUserLink 엔티티 생성 및 저장
-            for (Reference reference : newReferences) {
-                ReferenceUserLink referenceUserLink = ReferenceUserLink.builder()
-                        .reference(reference)
-                        .userLink(userLink)
-                        .build();
-                referenceUserLinkRepository.save(referenceUserLink);
-            }
-
-            references = newReferences;
+            ReferenceUserLink referenceUserLink = ReferenceUserLink.builder()
+                    .reference(reference)
+                    .userLink(userLink)
+                    .build();
+            referenceUserLinkRepository.save(referenceUserLink);
         } else {
-            // referenceIds가 null이면 기존 Reference 유지
-            List<ReferenceUserLink> referenceUserLinks = referenceUserLinkRepository.findByUserLinkId(userLinkId);
-            references = referenceUserLinks.stream()
+            // referenceId가 null이면 기존 Reference 유지
+            reference = referenceUserLinkRepository.findByUserLinkId(userLinkId).stream()
                     .map(ReferenceUserLink::getReference)
-                    .collect(Collectors.toList());
+                    .findFirst()
+                    .orElse(null);
         }
 
-        log.info("사용자 링크 수정 완료 - userId: {}, userLinkId: {}, referenceCount: {}",
-                userId, userLinkId, references.size());
+        log.info("사용자 링크 수정 완료 - userId: {}, userLinkId: {}, referenceId: {}",
+                userId, userLinkId, reference != null ? reference.getId() : "null");
 
-        return UserLinkResponse.from(userLink, references);
+        return UserLinkResponse.from(userLink, reference);
     }
 
     /**
-     * 사용자 링크 삭제
-     * - ReferenceUserLink도 함께 삭제
+     * 사용자 링크 삭제 - ReferenceUserLink도 함께 삭제
      */
     @Transactional
     public void deleteUserLink(Long userId, Long userLinkId) {
@@ -236,24 +224,24 @@ public class UserLinkService {
 
         userLink.markAsRead();
 
-        // UserLink에 연결된 Reference 목록 조회
-        List<ReferenceUserLink> referenceUserLinks = referenceUserLinkRepository.findByUserLinkId(userLinkId);
-        List<Reference> references = referenceUserLinks.stream()
+        // UserLink에 연결된 Reference 조회 (단일)
+        Reference reference = referenceUserLinkRepository.findByUserLinkId(userLinkId).stream()
                 .map(ReferenceUserLink::getReference)
-                .collect(Collectors.toList());
+                .findFirst()
+                .orElse(null);
 
         log.info("사용자 링크 읽음 처리 완료 - userId: {}, userLinkId: {}", userId, userLinkId);
 
-        return UserLinkResponse.from(userLink, references);
+        return UserLinkResponse.from(userLink, reference);
     }
 
     /**
      * 사용자 링크 목록 조회 (커서 페이징)
      *
-     * @param userId 현재 사용자 ID
+     * @param userId      현재 사용자 ID
      * @param referenceId 레퍼런스 ID (null이면 전체 조회, 값이 있으면 특정 레퍼런스 조회)
-     * @param cursor 커서 (null이면 첫 페이지)
-     * @param size 페이지 크기
+     * @param cursor      커서 (null이면 첫 페이지)
+     * @param size        페이지 크기
      * @return 커서 기반 페이징 응답
      */
     public PageResponse<UserLinkListResponse> getUserLinksByReferenceId(
@@ -290,6 +278,7 @@ public class UserLinkService {
 
     /**
      * UserLink 목록을 UserLinkListResponse로 변환
+     *
      * @param targetReference 조회한 레퍼런스 (null이면 모든 레퍼런스 포함)
      */
     private PageResponse<UserLinkListResponse> buildUserLinkListResponse(
@@ -311,7 +300,8 @@ public class UserLinkService {
                         references = List.of(targetReference);
                     } else {
                         // 전체 조회인 경우, UserLink에 연결된 모든 Reference 포함
-                        List<ReferenceUserLink> referenceUserLinks = referenceUserLinkRepository.findByUserLinkId(userLink.getId());
+                        List<ReferenceUserLink> referenceUserLinks = referenceUserLinkRepository.findByUserLinkId(
+                                userLink.getId());
                         references = referenceUserLinks.stream()
                                 .map(ReferenceUserLink::getReference)
                                 .collect(Collectors.toList());

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
@@ -57,7 +57,7 @@ public class UserLinkService {
         boolean hasNewReference = request.newReference() != null && request.newReference().title() != null;
 
         if (hasReferenceId && hasNewReference) {
-            throw new ReferenceSelectionDuplicateException("기존 폴더 선택과 새 폴더 생성은 동시에 사용할 수 없습니다.");
+            throw new ReferenceSelectionDuplicateException();
         }
 
         // URL로 기존 Link 조회
@@ -130,7 +130,7 @@ public class UserLinkService {
 
         // 소유자 검증
         if (userId == null) {
-            throw new UserLinkAccessDeniedException("링크 조회는 로그인이 필요합니다.");
+            throw new UserLinkAccessDeniedException();
         }
         userLink.validateOwner(userId);
 

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
@@ -45,8 +45,8 @@ public class UserLinkService {
     private final ReferenceService referenceService;
 
     /**
-     * 사용자 링크 생성 - 중복 체크를 먼저 수행한 후 Link 생성 - LinkService를 통해 Link 스크래핑 로직 처리 - referenceId와 newReference는 상호 배타적 (둘 중
-     * 하나만 선택) - 둘 다 null이면 기본 미지정 폴더에 자동 분류
+     * 사용자 링크 생성 - 중복 체크를 먼저 수행한 후 Link 생성 - LinkService를 통해 Link 스크래핑 로직 처리 referenceId와 newReference는 둘 중 하나만 선택 둘 다
+     * null이면 기본 미지정 폴더에 자동 분류
      */
     @Transactional
     public UserLinkResponse createUserLink(Long userId, UserLinkCreateRequest request) {
@@ -87,7 +87,7 @@ public class UserLinkService {
 
         UserLink savedUserLink = userLinkRepository.save(userLink);
 
-        // ReferenceUserLink 생성 (상호 배타적: 기존 폴더 OR 새 폴더 OR 미지정)
+        // ReferenceUserLink 생성 (기존 폴더 OR 새 폴더 OR 미지정)
         Reference reference;
 
         if (hasReferenceId) {
@@ -148,7 +148,10 @@ public class UserLinkService {
     }
 
     /**
-     * 사용자 링크 수정 - referenceId가 제공되면 기존 ReferenceUserLink를 삭제하고 새로 생성
+     * 사용자 링크 수정
+     * - referenceId가 제공되면 해당 폴더로 이동
+     * - moveToDefault가 true면 미지정 폴더로 이동
+     * - 둘 다 없으면 기존 폴더 유지
      */
     @Transactional
     public UserLinkResponse updateUserLink(Long userId, Long userLinkId, UserLinkUpdateRequest request) {
@@ -157,31 +160,46 @@ public class UserLinkService {
         // 소유자 검증
         userLink.validateOwner(userId);
 
+        // referenceId와 moveToDefault 동시 사용 검증
+        if (request.referenceId() != null && Boolean.TRUE.equals(request.moveToDefault())) {
+            throw new ReferenceSelectionDuplicateException();
+        }
+
         // 수정 (null이면 기존값 유지)
         userLink.updateUserLink(
                 request.why() != null ? request.why() : userLink.getWhy(),
                 request.memo() != null ? request.memo() : userLink.getMemo()
         );
 
-        // Reference 처리 (referenceId가 제공된 경우에만)
+        // Reference 처리
         Reference reference;
-        if (request.referenceId() != null) {
-            // 기존 ReferenceUserLink 삭제
+        if (Boolean.TRUE.equals(request.moveToDefault())) {
+            // 1. 미지정 폴더로 이동
             referenceUserLinkRepository.deleteByUserLinkId(userLinkId);
 
-            // 새로운 Reference 결정
-            // referenceId로 Reference 조회 및 검증
+            reference = referenceService.getOrCreateDefaultReference(userId);
+
+            ReferenceUserLink referenceUserLink = ReferenceUserLink.builder()
+                    .reference(reference)
+                    .userLink(userLink)
+                    .build();
+            referenceUserLinkRepository.save(referenceUserLink);
+
+            log.info("사용자 링크 미지정 폴더로 이동 - userId: {}, userLinkId: {}", userId, userLinkId);
+        } else if (request.referenceId() != null) {
+            // 2. 지정된 폴더로 이동
+            referenceUserLinkRepository.deleteByUserLinkId(userLinkId);
+
             reference = getReferenceById(request.referenceId());
             reference.validateOwner(userId);
 
-            // ReferenceUserLink 엔티티 생성 및 저장
             ReferenceUserLink referenceUserLink = ReferenceUserLink.builder()
                     .reference(reference)
                     .userLink(userLink)
                     .build();
             referenceUserLinkRepository.save(referenceUserLink);
         } else {
-            // referenceId가 null이면 기존 Reference 유지
+            // 3. 기존 폴더 유지
             reference = referenceUserLinkRepository.findByUserLinkId(userLinkId).stream()
                     .map(ReferenceUserLink::getReference)
                     .findFirst()

--- a/src/main/java/swyp12/team9/server/global/config/SecurityConfig.java
+++ b/src/main/java/swyp12/team9/server/global/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package swyp12.team9.server.global.config;
 
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -31,9 +33,6 @@ import swyp12.team9.server.global.filter.LoginFilter;
 import swyp12.team9.server.global.handler.CustomAccessDeniedHandler;
 import swyp12.team9.server.global.handler.CustomAuthenticationEntryPoint;
 import swyp12.team9.server.global.handler.RefreshTokenLogoutHandler;
-
-import java.util.Arrays;
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -108,51 +107,52 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 필터 설정 (STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        // 공개 엔드포인트
-                        .requestMatchers(
-                                "/api/health",
-                                "/actuator/**",
-                                "/swagger-ui/**",
-                                "/v3/api-docs/**",
-                                "/swagger-resources/**"
-                        ).permitAll()  // TODO: 인증 구현 후 수정 필요
+                                // 공개 엔드포인트
+                                .requestMatchers(
+                                        "/api/health",
+                                        "/actuator/**",
+                                        "/swagger-ui/**",
+                                        "/v3/api-docs/**",
+                                        "/swagger-resources/**"
+                                ).permitAll()  // TODO: 인증 구현 후 수정 필요
 
-                        // 인증 관련
-                        .requestMatchers("/api/v1/jwt/exchange", "/api/v1/jwt/refresh", "/api/v1/auth/logout").permitAll()
-                        .requestMatchers(HttpMethod.POST,
-                                "/api/v1/users/exist",
-                                "/api/v1/users/signup",
-                                "/api/v1/auth/login"
-                        ).permitAll()
+                                // 인증 관련
+                                .requestMatchers("/api/v1/jwt/exchange", "/api/v1/jwt/refresh", "/api/v1/auth/logout")
+                                .permitAll()
+                                .requestMatchers(HttpMethod.POST,
+                                        "/api/v1/users/exist",
+                                        "/api/v1/users/signup",
+                                        "/api/v1/auth/login"
+                                ).permitAll()
 
-                        // OAuth2 소셜 로그인 관련 경로
-                        .requestMatchers("/api/v1/oauth2/**", "/api/v1/login/oauth2/code/**").permitAll()
+                                // OAuth2 소셜 로그인 관련 경로
+                                .requestMatchers("/api/v1/oauth2/**", "/api/v1/login/oauth2/code/**").permitAll()
 
-                        // 레퍼런스 조회 (익명 허용 - Service에서 type별 권한 체크)
-                        .requestMatchers(HttpMethod.GET, "/api/v1/references/{referenceId}").permitAll()
+                                // 레퍼런스 조회 (익명 허용 - Service에서 type별 권한 체크)
+                                .requestMatchers(HttpMethod.GET, "/api/v1/references/{referenceId}").permitAll()
 //                        .requestMatchers(HttpMethod.GET, "/api/v1/references").permitAll()
 
-                        // 사용자 링크 조회 (익명 허용 - Service에서 type별 권한 체크)
-                        .requestMatchers(HttpMethod.GET, "/api/v1/user-links/{userLinkId}").permitAll()
+                                // 사용자 링크 조회 (익명 허용 - Service에서 type별 권한 체크)
+                                .requestMatchers(HttpMethod.GET, "/api/v1/user-links/{userLinkId}").permitAll()
 //                        .requestMatchers(HttpMethod.GET, "/api/v1/user-links").permitAll()
 
-                        // 관리자 전용 API (가장 먼저 체크)
-                        .requestMatchers("/api/v1/references/admin/**").hasRole("ADMIN")  // 관리자 전용
+                                // 관리자 전용 API (가장 먼저 체크)
+                                .requestMatchers("/api/v1/references/admin/**").hasRole("ADMIN")  // 관리자 전용
 
-                        // API v1 전체 (인증 필요)
-                        .requestMatchers(HttpMethod.POST, "/api/v1/**").hasRole(UserRole.USER.name())
-                        .requestMatchers(HttpMethod.GET, "/api/v1/**").hasRole(UserRole.USER.name())
-                        .requestMatchers(HttpMethod.PUT, "/api/v1/**").hasRole(UserRole.USER.name())
-                        .requestMatchers(HttpMethod.PATCH, "/api/v1/**").hasRole(UserRole.USER.name())
-                        .requestMatchers(HttpMethod.DELETE, "/api/v1/**").hasRole(UserRole.USER.name())
+                                // API v1 전체 (인증 필요)
+                                .requestMatchers(HttpMethod.POST, "/api/v1/**").hasRole(UserRole.USER.name())
+                                .requestMatchers(HttpMethod.GET, "/api/v1/**").hasRole(UserRole.USER.name())
+                                .requestMatchers(HttpMethod.PUT, "/api/v1/**").hasRole(UserRole.USER.name())
+                                .requestMatchers(HttpMethod.PATCH, "/api/v1/**").hasRole(UserRole.USER.name())
+                                .requestMatchers(HttpMethod.DELETE, "/api/v1/**").hasRole(UserRole.USER.name())
 
-                        // ========== User API ==========
-                        .requestMatchers(HttpMethod.GET, "/api/v1/users/*").hasRole(UserRole.USER.name())
-                        .requestMatchers(HttpMethod.PUT, "/api/v1/users/*").hasRole(UserRole.USER.name())
-                        .requestMatchers(HttpMethod.DELETE, "/api/v1/users/*").hasRole(UserRole.USER.name())
+                                // ========== User API ==========
+                                .requestMatchers(HttpMethod.GET, "/api/v1/users/*").hasRole(UserRole.USER.name())
+                                .requestMatchers(HttpMethod.PUT, "/api/v1/users/*").hasRole(UserRole.USER.name())
+                                .requestMatchers(HttpMethod.DELETE, "/api/v1/users/*").hasRole(UserRole.USER.name())
 
-                        // ========== 나머지 모든 요청 ==========
-                        .anyRequest().authenticated()
+                                // ========== 나머지 모든 요청 ==========
+                                .anyRequest().authenticated()
                 )
                 .formLogin(AbstractHttpConfigurer::disable)        // 기본 Form 기반 인증 필터들 disable
                 .httpBasic(AbstractHttpConfigurer::disable);       // 기본 Basic 인증 필터 disable
@@ -178,10 +178,9 @@ public class SecurityConfig {
                         .logoutUrl("/api/v1/auth/logout")
                         .addLogoutHandler(new RefreshTokenLogoutHandler(jwtService))
                         .logoutSuccessHandler((request, response, authentication) -> {
-                            response.setStatus(HttpServletResponse.SC_OK);
+                            response.setStatus(HttpServletResponse.SC_NO_CONTENT);
                             response.setContentType("application/json");
                             response.setCharacterEncoding("UTF-8");
-                            response.getWriter().write("{\"message\": \"로그아웃 성공\"}");
                         }));
 
         // 예외 처리 (ErrorCode 기반 JSON 응답)
@@ -209,7 +208,6 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder();
     }
 }
-
 
 // ✅ 올바른 순서
 //1. 공개 엔드포인트 (permitAll)

--- a/src/main/java/swyp12/team9/server/global/config/SecurityConfig.java
+++ b/src/main/java/swyp12/team9/server/global/config/SecurityConfig.java
@@ -179,8 +179,6 @@ public class SecurityConfig {
                         .addLogoutHandler(new RefreshTokenLogoutHandler(jwtService))
                         .logoutSuccessHandler((request, response, authentication) -> {
                             response.setStatus(HttpServletResponse.SC_NO_CONTENT);
-                            response.setContentType("application/json");
-                            response.setCharacterEncoding("UTF-8");
                         }));
 
         // 예외 처리 (ErrorCode 기반 JSON 응답)

--- a/src/main/java/swyp12/team9/server/global/exception/ErrorCode.java
+++ b/src/main/java/swyp12/team9/server/global/exception/ErrorCode.java
@@ -45,7 +45,7 @@ public enum ErrorCode {
     REFERENCE_TITLE_DUPLICATE(HttpStatus.CONFLICT, "REF003", "이미 존재하는 레퍼런스 제목입니다"),
     REFERENCE_DEFAULT_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "REF004", "기본 레퍼런스는 수정/삭제할 수 없습니다"),
     REFERENCE_DEFAULT_CANNOT_DELETE(HttpStatus.BAD_REQUEST, "REF005", "기본 미지정 폴더는 삭제할 수 없습니다"),
-    REFERENCE_SELECTION_DUPLICATE(HttpStatus.BAD_REQUEST, "REF006", "기존 폴더 선택과 새 폴더 생성은 동시에 수행할 수 없습니다."),
+    REFERENCE_SELECTION_DUPLICATE(HttpStatus.BAD_REQUEST, "REF006", "폴더 지정 옵션은 하나만 선택할 수 있습니다"),
 
     // Image
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMG001", "이미지 업로드에 실패했습니다"),

--- a/src/main/java/swyp12/team9/server/global/exception/ErrorCode.java
+++ b/src/main/java/swyp12/team9/server/global/exception/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
     REFERENCE_TITLE_DUPLICATE(HttpStatus.CONFLICT, "REF003", "이미 존재하는 레퍼런스 제목입니다"),
     REFERENCE_DEFAULT_NOT_MODIFIABLE(HttpStatus.BAD_REQUEST, "REF004", "기본 레퍼런스는 수정/삭제할 수 없습니다"),
     REFERENCE_DEFAULT_CANNOT_DELETE(HttpStatus.BAD_REQUEST, "REF005", "기본 미지정 폴더는 삭제할 수 없습니다"),
+    REFERENCE_SELECTION_DUPLICATE(HttpStatus.BAD_REQUEST, "REF006", "기존 폴더 선택과 새 폴더 생성은 동시에 수행할 수 없습니다."),
 
     // Image
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "IMG001", "이미지 업로드에 실패했습니다"),
@@ -65,7 +66,6 @@ public enum ErrorCode {
     USER_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "ULK001", "사용자 링크를 찾을 수 없습니다"),
     USER_LINK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "ULK002", "사용자 링크에 접근할 수 없습니다"),
     USER_LINK_DUPLICATE(HttpStatus.CONFLICT, "ULK003", "이미 저장된 링크입니다"),
-
 
     ;
 

--- a/src/main/java/swyp12/team9/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/swyp12/team9/server/global/exception/GlobalExceptionHandler.java
@@ -167,27 +167,6 @@ public class GlobalExceptionHandler {
 
 
     /**
-     * @CurrentUserId 인증 실패
-     */
-    @ExceptionHandler(IllegalStateException.class)
-    protected ResponseEntity<ErrorResponse> handleIllegalStateException(IllegalStateException e) {
-        String errorMessage = e.getMessage() != null ? e.getMessage() : "알 수 없는 상태 오류";
-        log.error("[IllegalStateException] {}", errorMessage);
-
-        if (errorMessage.contains("인증이 필요합니다")) {
-            ErrorCode errorCode = ErrorCode.UNAUTHORIZED;
-            return ResponseEntity
-                    .status(errorCode.getHttpStatus())
-                    .body(ErrorResponse.of(errorCode));
-        }
-
-        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
-        return ResponseEntity
-                .status(errorCode.getHttpStatus())
-                .body(ErrorResponse.of(errorCode));
-    }
-
-    /**
      * 최종 안전망 - 예상하지 못한 모든 예외
      * - RuntimeException 핸들러 제거하고 Exception만 유지
      */

--- a/src/main/java/swyp12/team9/server/global/resolver/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/swyp12/team9/server/global/resolver/CurrentUserIdArgumentResolver.java
@@ -9,13 +9,13 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
-import swyp12.team9.server.global.security.CustomUserDetails;
-import swyp12.team9.server.global.annotation.CurrentUserId;
 import swyp12.team9.server.domain.auth.exception.UnauthorizedException;
+import swyp12.team9.server.domain.user.exception.UserNotFoundException;
+import swyp12.team9.server.global.annotation.CurrentUserId;
+import swyp12.team9.server.global.security.CustomUserDetails;
 
 /**
- * @CurrentUserId 어노테이션을 처리하는 ArgumentResolver
- * SecurityContext에서 CustomUserDetails를 가져와 userId를 추출
+ * @CurrentUserId 어노테이션을 처리하는 ArgumentResolver SecurityContext에서 CustomUserDetails를 가져와 userId를 추출
  */
 @Component
 public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResolver {
@@ -32,7 +32,6 @@ public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResol
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
-
 
         // @CurrentUserId 어노테이션 가져오기
         CurrentUserId annotation = parameter.getParameterAnnotation(CurrentUserId.class);
@@ -64,7 +63,7 @@ public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResol
 
         // CustomUserDetails가 아닌 경우
         if (required) {
-            throw new UnauthorizedException("사용자 정보를 찾을 수 없습니다.");
+            throw new UserNotFoundException("사용자 정보를 찾을 수 없습니다.");
         }
 
         return null;

--- a/src/main/java/swyp12/team9/server/global/resolver/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/swyp12/team9/server/global/resolver/CurrentUserIdArgumentResolver.java
@@ -47,7 +47,7 @@ public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResol
 
             if (required) {
                 // required=true: 예외 발생
-                throw new UnauthorizedException("인증이 필요합니다.");
+                throw new UnauthorizedException();
             } else {
                 // required=false: null 반환
                 return null;
@@ -63,7 +63,7 @@ public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResol
 
         // CustomUserDetails가 아닌 경우
         if (required) {
-            throw new UserNotFoundException("사용자 정보를 찾을 수 없습니다.");
+            throw new UserNotFoundException();
         }
 
         return null;

--- a/src/main/java/swyp12/team9/server/global/resolver/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/swyp12/team9/server/global/resolver/CurrentUserIdArgumentResolver.java
@@ -11,6 +11,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import swyp12.team9.server.global.security.CustomUserDetails;
 import swyp12.team9.server.global.annotation.CurrentUserId;
+import swyp12.team9.server.domain.auth.exception.UnauthorizedException;
 
 /**
  * @CurrentUserId 어노테이션을 처리하는 ArgumentResolver
@@ -47,7 +48,7 @@ public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResol
 
             if (required) {
                 // required=true: 예외 발생
-                throw new IllegalStateException("인증이 필요합니다.");
+                throw new UnauthorizedException("인증이 필요합니다.");
             } else {
                 // required=false: null 반환
                 return null;
@@ -63,7 +64,7 @@ public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResol
 
         // CustomUserDetails가 아닌 경우
         if (required) {
-            throw new IllegalStateException("사용자 정보를 찾을 수 없습니다.");
+            throw new UnauthorizedException("사용자 정보를 찾을 수 없습니다.");
         }
 
         return null;


### PR DESCRIPTION
## 📌 Issues Number
<!--
이 PR과 관련된 이슈 번호를 적어주세요.
예: closes #123, resolves #45
(자동으로 해당 이슈를 닫을 수 있습니다)
-->
- resolves #32 

## 📚 Summary
<!--
변경 사항의 요약과 배경을 작성해주세요.
왜 이 변경이 필요한지, 어떤 문제를 해결하는지, 주요 변경 내용을 간략히 기술합니다.
-->
  **UserLink API 개선 및 관련 버그 수정**                                                                                                                                    
  - 사용자 링크 생성 시 새 레퍼런스 폴더를 함께 생성할 수 있도록 기능 추가                                                                                               
  - 레퍼런스 폴더 선택 방식을 다중 선택에서 단일 선택으로 변경
  - 사용자 링크 수정 시 미지정 폴더로 이동하는 기능 추가                                                                                                               
  - UserLink 읽음 처리 로직 개선                                                                                                                                         
  - 인증 실패 예외 처리 방식 개선      

## 🧩 As-is
<!--
현재 코드/기능의 문제점이나 개선 전의 동작을 설명해주세요.
예:
- 로그인 실패 시 에러 메시지가 표시되지 않음
- API 응답 속도가 느림
-->
<img width="644" height="596" alt="image" src="https://github.com/user-attachments/assets/651c4e70-d622-44c8-a0fb-5a5c73a160fa" />

  - 사용자 링크 생성 시 기존 레퍼런스 폴더만 선택 가능하여, 새 폴더가 필요할 경우 별도 API 호출 필요                                                                     
  - 레퍼런스 폴더를 여러 개 선택 가능(List<Long> referenceIds)하여 API 복잡도 증가
  - 사용자 링크 수정 시 미지정 폴더로 이동하는 방법이 없음                                                                                          
  - UserLink 읽음 처리를 위한 별도 API 호출 필요                                                                                                                         
  - @CurrentUserId 인증 실패 시 IllegalStateException을 던지고 문자열 비교로 처리 (불안정)   

## 🚀 To-be
<!--
변경 후 기대되는 동작이나 개선된 부분을 작성해주세요.
예:
- 로그인 실패 시 에러 메시지 표시됨
- API 응답 속도 30% 향상
-->
  - 링크 생성 시 새 폴더 생성 가능                                                                                                                                       
    - newReference 필드로 제목/색상 코드 전달하여 폴더 생성과 링크 저장 동시 처리                                                                                        
    - referenceId와 newReference는 상호 배타적, 둘 다 null이면 미지정 폴더로 자동 분류                                                                                   
  - 레퍼런스 폴더 단일 선택                                                                                                                                              
    - List<Long> referenceIds → Long referenceId로 변경                                                                                                                  
  - 링크 수정 시 미지정 폴더 이동 기능                                                                                                                                   
    - moveToDefault: true 설정 시 사용자의 미지정 폴더로 이동                                                                                                            
    - referenceId와 moveToDefault는 상호 배타적, 둘 다 생략 시 기존 폴더 유지                                                                                            
  - 읽음 처리 자동화                                                                                                                                                     
    - 단건 조회 시 자동으로 isRead = true, viewCount++ 처리                                                                                                              
  - 인증 예외 처리 개선                                                                                                                                                  
    - UnauthorizedException 커스텀 예외 사용 (타입 기반 안전한 처리)   
  ---                                                                                                                                                                    
  변경된 파일 (12개)                                                                                                                                                     
  - UserLinkCreateRequest.java - referenceIds → referenceId + newReference 필드 추가                                                                                     
  - UserLinkUpdateRequest.java - 동일하게 단일 선택으로 변경                                                                                                             
  - UserLinkService.java - 새 폴더 생성 로직 및 읽음 처리 로직 통합, 미지정 폴더 이동 로직 추가3                                                                                                      
  - NewReferenceRequest.java - 새 레퍼런스 폴더 생성 DTO 추가                                                                                                            
  - UserLinkResponse.java - 응답 구조 개선                                                                                                                               
  - ReferenceService.java - createReferenceEntity 메서드 추가                                                                                                            
  - CurrentUserIdArgumentResolver.java - UnauthorizedException 사용                                                                                                      
  - GlobalExceptionHandler.java - IllegalStateException 핸들러 제거  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 링크 생성 및 수정 시 새로운 레퍼런스 폴더를 함께 생성할 수 있습니다.
  * 링크 조회 및 수정 시 확인 메시지가 표시됩니다.

* **기능 변경**
  * 각 링크는 이제 하나의 레퍼런스 폴더와 연결됩니다.
  * 링크 읽음 표시 API가 제거되었습니다.
  * 로그아웃 API 응답 상태 코드가 204로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->