### PR TITLE
feat: 스크래핑 연동 및 AI 요약 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ dependencies {
 	implementation 'software.amazon.awssdk:auth:2.20.26'
 
 	// Apache HttpComponents (RestClient용)
-	implementation 'org.apache.httpcomponents.client5:httpclient5:5.3'
+	implementation 'org.apache.httpcomponents.client5:httpclient5'
 
 	// QueryDSL
 	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
@@ -102,6 +102,7 @@ sourceSets {
 // QueryDSL 컴파일 시 Q 클래스 생성 디렉토리 설정
 tasks.withType(JavaCompile).configureEach {
 	options.generatedSourceOutputDirectory = file(generatedDir)
+	options.encoding = 'UTF-8'
 }
 
 // clean 시 생성된 Q 클래스 삭제

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 	implementation 'software.amazon.awssdk:s3:2.20.26'
 	implementation 'software.amazon.awssdk:auth:2.20.26'
 
+	// Apache HttpComponents (RestClient용)
+	implementation 'org.apache.httpcomponents.client5:httpclient5:5.3'
+
 	// QueryDSL
 	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
 	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"

--- a/src/main/java/swyp12/team9/server/domain/link/dto/ScrapingRequest.java
+++ b/src/main/java/swyp12/team9/server/domain/link/dto/ScrapingRequest.java
@@ -1,0 +1,15 @@
+package swyp12.team9.server.domain.link.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record ScrapingRequest(
+        @JsonProperty("max_length")
+        Integer maxLength,
+
+        @JsonProperty("url")
+        String url
+) {
+    public static ScrapingRequest of(String url, Integer maxLength) {
+        return new ScrapingRequest(maxLength, url);
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/link/dto/ScrapingResponse.java
+++ b/src/main/java/swyp12/team9/server/domain/link/dto/ScrapingResponse.java
@@ -21,6 +21,5 @@ public class ScrapingResponse {
 
     private String url;
 
-    @JsonProperty("content")
     private String content;
 }

--- a/src/main/java/swyp12/team9/server/domain/link/dto/ScrapingResponse.java
+++ b/src/main/java/swyp12/team9/server/domain/link/dto/ScrapingResponse.java
@@ -19,9 +19,6 @@ public class ScrapingResponse {
     @JsonProperty("favicon_url")
     private String faviconUrl;
 
-    @JsonProperty("thumbnail_url")
-    private String thumbnailUrl;
-
     private String url;
 
     @JsonProperty("content")

--- a/src/main/java/swyp12/team9/server/domain/link/dto/ScrapingResponse.java
+++ b/src/main/java/swyp12/team9/server/domain/link/dto/ScrapingResponse.java
@@ -1,0 +1,29 @@
+package swyp12.team9.server.domain.link.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScrapingResponse {
+
+    private Boolean success;
+
+    private String title;
+
+    private String description;
+
+    @JsonProperty("favicon_url")
+    private String faviconUrl;
+
+    @JsonProperty("thumbnail_url")
+    private String thumbnailUrl;
+
+    private String url;
+
+    @JsonProperty("content")
+    private String content;
+}

--- a/src/main/java/swyp12/team9/server/domain/link/exception/LinkInvalidUrlException.java
+++ b/src/main/java/swyp12/team9/server/domain/link/exception/LinkInvalidUrlException.java
@@ -1,0 +1,18 @@
+package swyp12.team9.server.domain.link.exception;
+
+import swyp12.team9.server.global.exception.BusinessException;
+import swyp12.team9.server.global.exception.ErrorCode;
+
+/**
+ * URL 형식이 유효하지 않을 때 발생하는 예외
+ */
+public class LinkInvalidUrlException extends BusinessException {
+
+    public LinkInvalidUrlException() {
+        super(ErrorCode.LINK_INVALID_URL);
+    }
+
+    public LinkInvalidUrlException(String message) {
+        super(ErrorCode.LINK_INVALID_URL, message);
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/link/exception/LinkScrapingServerException.java
+++ b/src/main/java/swyp12/team9/server/domain/link/exception/LinkScrapingServerException.java
@@ -1,0 +1,11 @@
+package swyp12.team9.server.domain.link.exception;
+
+import swyp12.team9.server.global.exception.BusinessException;
+import swyp12.team9.server.global.exception.ErrorCode;
+
+public class LinkScrapingServerException extends BusinessException {
+
+    public LinkScrapingServerException() {
+        super(ErrorCode.LINK_SCRAPING_SERVER_ERROR);
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/link/exception/LinkScrapingTimeoutException.java
+++ b/src/main/java/swyp12/team9/server/domain/link/exception/LinkScrapingTimeoutException.java
@@ -1,0 +1,11 @@
+package swyp12.team9.server.domain.link.exception;
+
+import swyp12.team9.server.global.exception.BusinessException;
+import swyp12.team9.server.global.exception.ErrorCode;
+
+public class LinkScrapingTimeoutException extends BusinessException {
+
+    public LinkScrapingTimeoutException() {
+        super(ErrorCode.LINK_SCRAPING_TIMEOUT);
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/link/model/Link.java
+++ b/src/main/java/swyp12/team9/server/domain/link/model/Link.java
@@ -25,17 +25,36 @@ public class Link extends BaseEntity {
     @Column(name = "description", length = 1000)
     private String description;
 
-    @Column(name = "preview_image_url", length = 1024)
-    private String previewImageUrl;
+    @Column(name = "favicon_url", length = 1024)
+    private String faviconUrl;
+
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
 
     @Column(name = "ai_summary", columnDefinition = "TEXT")
     private String aiSummary;
 
     @Builder
-    public Link(String url, String title, String description, String previewImageUrl) {
+    public Link(String url, String title, String description, String faviconUrl, String content, String aiSummary) {
         this.url = url;
         this.title = title;
         this.description = description;
-        this.previewImageUrl = previewImageUrl;
+        this.faviconUrl = faviconUrl;
+        this.content = content;
+        this.aiSummary = aiSummary;
+    }
+
+    public static Link create(String url, String title, String description, String faviconUrl, String content) {
+        return Link.builder()
+                .url(url)
+                .title(title)
+                .description(description)
+                .faviconUrl(faviconUrl)
+                .content(content)
+                .build();
+    }
+
+    public void updateAiSummary(String aiSummary) {
+        this.aiSummary = aiSummary;
     }
 }

--- a/src/main/java/swyp12/team9/server/domain/link/service/LinkAiService.java
+++ b/src/main/java/swyp12/team9/server/domain/link/service/LinkAiService.java
@@ -43,8 +43,8 @@ public class LinkAiService {
                 1. 3-5문장으로 핵심 내용만 요약
                 2. 핵심 키워드 포함
                 3. 존재하지 않는 정보를 지어내지 말 것
-                3. 이 링크가 왜 유용한지 설명
-                4. 한국어로 작성
+                4. 이 링크가 왜 유용한지 설명
+                5. 한국어로 작성
                 """;
 
         PromptTemplate promptTemplate = new PromptTemplate(promptText);

--- a/src/main/java/swyp12/team9/server/domain/link/service/LinkAiService.java
+++ b/src/main/java/swyp12/team9/server/domain/link/service/LinkAiService.java
@@ -11,10 +11,13 @@ import java.util.Map;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class LinkAiService {
 
-    private final ChatClient.Builder chatClientBuilder;
+    private final ChatClient chatClient;
+
+    public LinkAiService(ChatClient.Builder chatClientBuilder) {
+        this.chatClient = chatClientBuilder.build();
+    }
 
     /**
      * 링크 콘텐츠를 요약합니다.
@@ -22,45 +25,49 @@ public class LinkAiService {
      * @param title   링크 제목
      * @param description 링크 설명
      * @param content 링크 콘텐츠 미리보기
-     * @return AI 요약 텍스트
+     * @return AI 요약 텍스트 (실패 시 null)
      */
     public String summarizeLink(String title, String description, String content) {
-        // 콘텐츠 정보가 충분하지 않으면 null 반환
-        if (isContentInsufficient(title, description, content)) {
-            log.warn("요약할 콘텐츠가 부족합니다.");
+        try {
+            // 콘텐츠 정보가 충분하지 않으면 null 반환
+            if (isContentInsufficient(title, description, content)) {
+                log.warn("요약할 콘텐츠가 부족합니다.");
+                return null;
+            }
+
+            // 프롬프트 템플릿 생성
+            String promptText = """
+                    다음 웹 링크 정보를 한국어로 간단히 요약해주세요.
+
+                    제목: {title}
+                    설명: {description}
+                    내용: {content}
+
+                    요약은 다음 규칙을 따라주세요:
+                    1. 3-5문장으로 핵심 내용만 요약
+                    2. 핵심 키워드 포함
+                    3. 존재하지 않는 정보를 지어내지 말 것
+                    4. 이 링크가 왜 유용한지 설명
+                    5. 한국어로 작성
+                    """;
+
+            PromptTemplate promptTemplate = new PromptTemplate(promptText);
+            Prompt prompt = promptTemplate.create(Map.of(
+                    "title", title != null ? title : "제목 없음",
+                    "description", description != null ? description : "설명 없음",
+                    "content", content != null ? content : "내용 없음"
+            ));
+
+            String summary = chatClient.prompt(prompt)
+                    .call()
+                    .content();
+
+            log.info("AI 요약 생성 완료");
+            return summary;
+        } catch (Exception e) {
+            log.error("AI 요약 생성 실패 - title: {}, error: {}", title, e.getMessage(), e);
             return null;
         }
-
-        // 프롬프트 템플릿 생성
-        String promptText = """
-                다음 웹 링크 정보를 한국어로 간단히 요약해주세요.
-
-                제목: {title}
-                설명: {description}
-                내용: {content}
-
-                요약은 다음 규칙을 따라주세요:
-                1. 3-5문장으로 핵심 내용만 요약
-                2. 핵심 키워드 포함
-                3. 존재하지 않는 정보를 지어내지 말 것
-                4. 이 링크가 왜 유용한지 설명
-                5. 한국어로 작성
-                """;
-
-        PromptTemplate promptTemplate = new PromptTemplate(promptText);
-        Prompt prompt = promptTemplate.create(Map.of(
-                "title", title != null ? title : "제목 없음",
-                "description", description != null ? description : "설명 없음",
-                "content", content != null ? content : "내용 없음"
-        ));
-
-        ChatClient chatClient = chatClientBuilder.build();
-        String summary = chatClient.prompt(prompt)
-                .call()
-                .content();
-
-        log.info("AI 요약 생성 완료");
-        return summary;
     }
 
     /**

--- a/src/main/java/swyp12/team9/server/domain/link/service/LinkAiService.java
+++ b/src/main/java/swyp12/team9/server/domain/link/service/LinkAiService.java
@@ -1,0 +1,77 @@
+package swyp12.team9.server.domain.link.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LinkAiService {
+
+    private final ChatClient.Builder chatClientBuilder;
+
+    /**
+     * 링크 콘텐츠를 요약합니다.
+     *
+     * @param title   링크 제목
+     * @param description 링크 설명
+     * @param content 링크 콘텐츠 미리보기
+     * @return AI 요약 텍스트
+     */
+    public String summarizeLink(String title, String description, String content) {
+        // 콘텐츠 정보가 충분하지 않으면 null 반환
+        if (isContentInsufficient(title, description, content)) {
+            log.warn("요약할 콘텐츠가 부족합니다.");
+            return null;
+        }
+
+        // 프롬프트 템플릿 생성
+        String promptText = """
+                다음 웹 링크 정보를 한국어로 간단히 요약해주세요.
+
+                제목: {title}
+                설명: {description}
+                내용: {content}
+
+                요약은 다음 규칙을 따라주세요:
+                1. 3-5문장으로 핵심 내용만 요약
+                2. 핵심 키워드 포함
+                3. 존재하지 않는 정보를 지어내지 말 것
+                3. 이 링크가 왜 유용한지 설명
+                4. 한국어로 작성
+                """;
+
+        PromptTemplate promptTemplate = new PromptTemplate(promptText);
+        Prompt prompt = promptTemplate.create(Map.of(
+                "title", title != null ? title : "제목 없음",
+                "description", description != null ? description : "설명 없음",
+                "content", content != null ? content : "내용 없음"
+        ));
+
+        ChatClient chatClient = chatClientBuilder.build();
+        String summary = chatClient.prompt(prompt)
+                .call()
+                .content();
+
+        log.info("AI 요약 생성 완료");
+        return summary;
+    }
+
+    /**
+     * 콘텐츠가 요약하기에 충분한지 확인
+     * 제목은 무조건, 설명 or 내용 중 최소 하나는 있어야 함
+     */
+    private boolean isContentInsufficient(String title, String description, String content) {
+        boolean titleEmpty = title == null || title.trim().isEmpty();
+        boolean descriptionEmpty = description == null || description.trim().isEmpty();
+        boolean contentEmpty = content == null || content.trim().isEmpty();
+
+        return titleEmpty || (descriptionEmpty && contentEmpty);
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/link/service/LinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/link/service/LinkService.java
@@ -1,0 +1,86 @@
+package swyp12.team9.server.domain.link.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import swyp12.team9.server.domain.link.dto.ScrapingResponse;
+import swyp12.team9.server.domain.link.model.Link;
+import swyp12.team9.server.domain.link.repository.LinkRepository;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class LinkService {
+
+    private final LinkRepository linkRepository;
+    private final ScrapingService scrapingService;
+    private final LinkAiService linkAiService;
+
+    /**
+     * 스크래핑을 통해 새로운 Link를 생성합니다.
+     *
+     * @param url 스크래핑할 URL
+     * @return 생성된 Link 엔티티
+     */
+    @Transactional
+    public Link createLink(String url) {
+        log.info("새로운 Link 생성 시작 - URL: {}", url);
+
+        // 스크래핑 API 호출
+        ScrapingResponse scrapingData = scrapingService.scrapeUrl(url, 500);
+
+        // Link 생성 및 저장
+        Link link = createLinkFromScrapingData(scrapingData, url);
+
+        // AI 요약 추가 TODO 박현제: AI 요청 로직 비동기로 수정
+        addAiSummaryToLink(link, scrapingData);
+
+        return link;
+    }
+
+    /**
+     * 스크래핑 데이터로부터 Link를 생성하고 저장합니다.
+     *
+     * @param scrapingData 스크래핑 결과
+     * @param url 원본 URL
+     * @return 저장된 Link 엔티티
+     */
+    private Link createLinkFromScrapingData(ScrapingResponse scrapingData, String url) {
+        Link link = Link.create(
+                scrapingData.getUrl(),
+                scrapingData.getTitle(),
+                scrapingData.getDescription(),
+                scrapingData.getFaviconUrl(),
+                scrapingData.getContent()
+        );
+
+        link = linkRepository.save(link);
+        log.info("Link 저장 완료 - linkId: {}, title: {}", link.getId(), scrapingData.getTitle());
+
+        return link;
+    }
+
+    /**
+     * Link에 AI 요약을 추가합니다.
+     *
+     * @param link 대상 Link
+     * @param scrapingData 스크래핑 데이터
+     */
+    private void addAiSummaryToLink(Link link, ScrapingResponse scrapingData) {
+        String aiSummary = linkAiService.summarizeLink(
+                scrapingData.getTitle(),
+                scrapingData.getDescription(),
+                scrapingData.getContent()
+        );
+
+        if (aiSummary != null && !aiSummary.trim().isEmpty()) {
+            link.updateAiSummary(aiSummary);
+            log.info("AI 요약 완료 - linkId: {}", link.getId());
+        } else {
+            log.warn("AI 요약 실패 - linkId: {}", link.getId());
+        }
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/link/service/LinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/link/service/LinkService.java
@@ -50,7 +50,7 @@ public class LinkService {
      */
     private Link createLinkFromScrapingData(ScrapingResponse scrapingData, String url) {
         Link link = Link.create(
-                scrapingData.getUrl(),
+                url,
                 scrapingData.getTitle(),
                 scrapingData.getDescription(),
                 scrapingData.getFaviconUrl(),

--- a/src/main/java/swyp12/team9/server/domain/link/service/ScrapingService.java
+++ b/src/main/java/swyp12/team9/server/domain/link/service/ScrapingService.java
@@ -1,0 +1,43 @@
+package swyp12.team9.server.domain.link.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import swyp12.team9.server.domain.link.dto.ScrapingRequest;
+import swyp12.team9.server.domain.link.dto.ScrapingResponse;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ScrapingService {
+
+    private final RestClient scrapingRestClient;
+
+    /**
+     * 외부 스크래핑 API를 호출하여 URL의 메타데이터를 가져옵니다.
+     *
+     * @param url        스크래핑할 URL
+     * @param maxLength  content_preview 최대 길이
+     * @return 스크래핑 결과
+     */
+    public ScrapingResponse scrapeUrl(String url, Integer maxLength) {
+        log.info("스크래핑 API 호출 - URL: {}", url);
+
+        ScrapingRequest request = ScrapingRequest.of(
+                url,
+                maxLength != null ? maxLength : 500
+        );
+
+        ScrapingResponse response = scrapingRestClient.post()
+                .uri("/api/v1/scrape")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(ScrapingResponse.class);
+
+        log.info("스크래핑 완료 - URL: {}", url);
+        return response;
+    }
+}

--- a/src/main/java/swyp12/team9/server/domain/recommendation/service/LinkIndexingService.java
+++ b/src/main/java/swyp12/team9/server/domain/recommendation/service/LinkIndexingService.java
@@ -178,7 +178,7 @@ public class LinkIndexingService {
         metadata.put("aiSummary", link.getAiSummary());
         metadata.put("why", userLink.getWhy() != null ? userLink.getWhy() : "");
         metadata.put("memo", userLink.getMemo() != null ? userLink.getMemo() : "");
-        metadata.put("thumbnailUrl", link.getPreviewImageUrl() != null ? link.getPreviewImageUrl() : "");
+        metadata.put("faviconUrl", link.getFaviconUrl() != null ? link.getFaviconUrl() : "");
 
         // 3. Document 생성 (ID는 "ul-{userLinkId}" 형식)
         // - 동일 ID로 재색인 시 upsert(업데이트) 동작

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
@@ -13,6 +13,7 @@ import swyp12.team9.server.api.userlink.dto.response.UserLinkListResponse;
 import swyp12.team9.server.api.userlink.dto.response.UserLinkResponse;
 import swyp12.team9.server.domain.link.model.Link;
 import swyp12.team9.server.domain.link.repository.LinkRepository;
+import swyp12.team9.server.domain.link.service.LinkService;
 import swyp12.team9.server.domain.reference.exception.ReferenceNotFoundException;
 import swyp12.team9.server.domain.reference.model.Reference;
 import swyp12.team9.server.domain.reference.repository.ReferenceRepository;
@@ -38,7 +39,7 @@ public class UserLinkService {
 
     private final UserLinkRepository userLinkRepository;
     private final LinkRepository linkRepository;
-    //    private final LinkService linkService; TODO 박현제: 스크래핑 로직 추가 예정
+    private final LinkService linkService;
     private final UserRepository userRepository;
     private final ReferenceRepository referenceRepository;
     private final ReferenceUserLinkRepository referenceUserLinkRepository;
@@ -64,17 +65,13 @@ public class UserLinkService {
         Link link = linkRepository.findByUrl(request.url()).orElse(null);
 
         // Link가 이미 존재하는 경우, 중복 체크 먼저 수행
-        if (link != null) {
-            if (userLinkRepository.existsByUserIdAndLinkId(userId, link.getId())) {
-                throw new UserLinkDuplicateException();
-            }
-        } else {
-            // Link가 없는 경우에만 스크래핑하여 새로 생성
-            Link newLink = Link.builder() // TODO 박현제: 임시. 이후 스크래핑 데이터로 변경 예정
-                    .url(request.url())
-                    .build();
-            link = linkRepository.save(newLink);
-//            link = linkService.createLinkFromScraping(request.url());
+        if (link != null && userLinkRepository.existsByUserIdAndLinkId(userId, link.getId())) {
+            throw new UserLinkDuplicateException();
+        }
+
+        // 링크가 없으면 생성
+        if (link == null) {
+            link = linkRepository.save(linkService.createLink(request.url()));
         }
 
         // UserLink 생성

--- a/src/main/java/swyp12/team9/server/global/config/RestClientConfig.java
+++ b/src/main/java/swyp12/team9/server/global/config/RestClientConfig.java
@@ -26,11 +26,6 @@ public class RestClientConfig {
     private String scrapingApiBaseUrl;
 
     @Bean
-    public RestClient restClient(RestClient.Builder builder) {
-        return builder.build();
-    }
-
-    @Bean
     public RestClient scrapingRestClient(RestClient.Builder builder, CloseableHttpClient httpClient) {
         HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClient);
 

--- a/src/main/java/swyp12/team9/server/global/config/RestClientConfig.java
+++ b/src/main/java/swyp12/team9/server/global/config/RestClientConfig.java
@@ -1,0 +1,45 @@
+package swyp12.team9.server.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+import swyp12.team9.server.domain.link.exception.LinkInvalidUrlException;
+import swyp12.team9.server.domain.link.exception.LinkScrapingServerException;
+import swyp12.team9.server.global.interceptor.ScrapingClientInterceptor;
+
+import java.time.Duration;
+
+@Configuration
+public class RestClientConfig {
+
+    @Value("${scraping.api.base-url:http://localhost:8000}")
+    private String scrapingApiBaseUrl;
+
+    @Bean
+    public RestClient restClient(RestClient.Builder builder) {
+        return builder.build();
+    }
+
+    @Bean
+    public RestClient scrapingRestClient(RestClient.Builder builder) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(5));
+        factory.setReadTimeout(Duration.ofSeconds(30));
+
+        return builder
+                .baseUrl(scrapingApiBaseUrl)
+                .requestFactory(new BufferingClientHttpRequestFactory(factory))
+                .requestInterceptor(new ScrapingClientInterceptor())
+                .defaultStatusHandler(HttpStatusCode::is4xxClientError, (request, response) -> {
+                    throw new LinkInvalidUrlException();
+                })
+                .defaultStatusHandler(HttpStatusCode::is5xxServerError, (request, response) -> {
+                    throw new LinkScrapingServerException();
+                })
+                .build();
+    }
+}

--- a/src/main/java/swyp12/team9/server/global/config/RestClientConfig.java
+++ b/src/main/java/swyp12/team9/server/global/config/RestClientConfig.java
@@ -1,17 +1,21 @@
 package swyp12.team9.server.global.config;
 
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.util.Timeout;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.client.BufferingClientHttpRequestFactory;
-import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 import swyp12.team9.server.domain.link.exception.LinkInvalidUrlException;
 import swyp12.team9.server.domain.link.exception.LinkScrapingServerException;
 import swyp12.team9.server.global.interceptor.ScrapingClientInterceptor;
-
-import java.time.Duration;
 
 @Configuration
 public class RestClientConfig {
@@ -25,10 +29,8 @@ public class RestClientConfig {
     }
 
     @Bean
-    public RestClient scrapingRestClient(RestClient.Builder builder) {
-        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(Duration.ofSeconds(5));
-        factory.setReadTimeout(Duration.ofSeconds(30));
+    public RestClient scrapingRestClient(RestClient.Builder builder, CloseableHttpClient httpClient) {
+        HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(httpClient);
 
         return builder
                 .baseUrl(scrapingApiBaseUrl)
@@ -40,6 +42,39 @@ public class RestClientConfig {
                 .defaultStatusHandler(HttpStatusCode::is5xxServerError, (request, response) -> {
                     throw new LinkScrapingServerException();
                 })
+                .build();
+    }
+
+    /**
+     * Apache HttpClient 설정
+     * - Connection Pool: 최대 50개 연결, 라우트당 20개
+     * - Timeout: 연결 5초, 응답 30초
+     * - Keep-Alive 활성화
+     */
+    @Bean
+    public CloseableHttpClient httpClient() {
+        // Connection Pool 설정
+        ConnectionConfig connectionConfig = ConnectionConfig.custom()
+                .setConnectTimeout(Timeout.ofSeconds(5))
+                .setSocketTimeout(Timeout.ofSeconds(30))
+                .build();
+
+        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+        connectionManager.setMaxTotal(50);  // 전체 최대 연결 수
+        connectionManager.setDefaultMaxPerRoute(20);  // 라우트당 최대 연결 수
+        connectionManager.setDefaultConnectionConfig(connectionConfig);
+
+        // Request 설정
+        RequestConfig requestConfig = RequestConfig.custom()
+                .setConnectionRequestTimeout(Timeout.ofSeconds(5))  // Connection Pool에서 연결 대기 시간
+                .setResponseTimeout(Timeout.ofSeconds(30))  // 응답 대기 시간
+                .build();
+
+        return HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .setDefaultRequestConfig(requestConfig)
+                .evictExpiredConnections()  // 만료된 연결 자동 제거
+                .evictIdleConnections(Timeout.ofSeconds(60))  // 60초 이상 idle 연결 제거
                 .build();
     }
 }

--- a/src/main/java/swyp12/team9/server/global/config/RestClientConfig.java
+++ b/src/main/java/swyp12/team9/server/global/config/RestClientConfig.java
@@ -1,5 +1,6 @@
 package swyp12.team9.server.global.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
@@ -18,6 +19,7 @@ import swyp12.team9.server.domain.link.exception.LinkScrapingServerException;
 import swyp12.team9.server.global.interceptor.ScrapingClientInterceptor;
 
 @Configuration
+@Slf4j
 public class RestClientConfig {
 
     @Value("${scraping.api.base-url:http://localhost:8000}")
@@ -37,9 +39,11 @@ public class RestClientConfig {
                 .requestFactory(new BufferingClientHttpRequestFactory(factory))
                 .requestInterceptor(new ScrapingClientInterceptor())
                 .defaultStatusHandler(HttpStatusCode::is4xxClientError, (request, response) -> {
+                    log.warn("스크래핑 API 4xx 에러 - URI: {}, Status: {}", request.getURI(), response.getStatusCode());
                     throw new LinkInvalidUrlException();
                 })
                 .defaultStatusHandler(HttpStatusCode::is5xxServerError, (request, response) -> {
+                    log.error("스크래핑 API 5xx 에러 - URI: {}, Status: {}", request.getURI(), response.getStatusCode());
                     throw new LinkScrapingServerException();
                 })
                 .build();

--- a/src/main/java/swyp12/team9/server/global/interceptor/ScrapingClientInterceptor.java
+++ b/src/main/java/swyp12/team9/server/global/interceptor/ScrapingClientInterceptor.java
@@ -1,0 +1,44 @@
+package swyp12.team9.server.global.interceptor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import swyp12.team9.server.domain.link.exception.LinkScrapingTimeoutException;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+
+/**
+ * 스크래핑 RestClient 인터셉터
+ * 요청/응답 로깅 및 타임아웃 예외 처리를 담당합니다.
+ */
+@Slf4j
+public class ScrapingClientInterceptor implements ClientHttpRequestInterceptor {
+
+    @Override
+    public ClientHttpResponse intercept(
+            HttpRequest request,
+            byte[] body,
+            ClientHttpRequestExecution execution
+    ) throws IOException {
+        log.debug("스크래핑 API 요청 - Method: {}, URI: {}", request.getMethod(), request.getURI());
+
+        try {
+            ClientHttpResponse response = execution.execute(request, body);
+            log.debug("스크래핑 API 응답 - Status: {}", response.getStatusCode());
+            return response;
+        } catch (SocketTimeoutException e) {
+            log.error("스크래핑 API 타임아웃 - URI: {}", request.getURI());
+            throw new LinkScrapingTimeoutException();
+        } catch (IOException e) {
+            // 타임아웃 관련 메시지 체크
+            if (e.getMessage() != null && (e.getMessage().contains("timeout") || e.getMessage().contains("timed out"))) {
+                log.error("스크래핑 API 타임아웃 - URI: {}", request.getURI());
+                throw new LinkScrapingTimeoutException();
+            }
+            throw e;
+        }
+    }
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -158,3 +158,8 @@ image:
   max-size: ${IMAGE_MAX_SIZE:10485760} # 10MB (byte 단위)
   allowed-types: image/jpeg,image/jpg,image/png,image/gif,image/webp
   directory: ${IMAGE_DIRECTORY:images} # 버킷 내 저장 경로
+
+# 스크래핑 API 설정
+scraping:
+  api:
+    base-url: ${SCRAPING_API_BASE_URL:http://localhost:8000}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -157,3 +157,8 @@ image:
   max-size: ${IMAGE_MAX_SIZE:10485760} # 10MB (byte 단위)
   allowed-types: image/jpeg,image/jpg,image/png,image/gif,image/webp
   directory: ${IMAGE_DIRECTORY:images} # 버킷 내 저장 경로
+
+# 스크래핑 API 설정
+scraping:
+  api:
+    base-url: ${SCRAPING_API_BASE_URL}

--- a/src/test/java/swyp12/team9/server/domain/link/fixture/LinkFixture.java
+++ b/src/test/java/swyp12/team9/server/domain/link/fixture/LinkFixture.java
@@ -1,0 +1,140 @@
+package swyp12.team9.server.domain.link.fixture;
+
+import swyp12.team9.server.domain.link.dto.ScrapingResponse;
+import swyp12.team9.server.domain.link.model.Link;
+
+public class LinkFixture {
+
+    public static final String URL = "https://example.com";
+    public static final String TITLE = "테스트 링크 제목";
+    public static final String DESCRIPTION = "테스트 링크 설명";
+    public static final String PREVIEW_IMAGE_URL = "https://example.com/preview.jpg";
+    public static final String FAVICON_URL = "https://example.com/favicon.ico";
+    public static final String CONTENT = "링크 컨텐츠입니다.";
+    public static final String AI_SUMMARY = "AI가 생성한 요약 내용입니다.";
+
+    /**
+     * 기본 Link 엔티티 생성
+     */
+    public static Link createLink() {
+        return Link.builder()
+                .url(URL)
+                .title(TITLE)
+                .description(DESCRIPTION)
+                .faviconUrl(FAVICON_URL)
+                .content(CONTENT)
+                .build();
+    }
+
+    /**
+     * ID가 설정된 Link 생성 (테스트용)
+     */
+    public static Link createLinkWithId(Long id) {
+        return new Link(
+                id,
+                URL,
+                TITLE,
+                DESCRIPTION,
+                PREVIEW_IMAGE_URL,
+                null,
+                CONTENT
+        );
+    }
+
+    /**
+     * 커스텀 URL로 Link 생성
+     */
+    public static Link createLinkWithUrl(String url) {
+        return Link.builder()
+                .url(url)
+                .title(TITLE)
+                .description(DESCRIPTION)
+                .faviconUrl(FAVICON_URL)
+                .content(CONTENT)
+                .build();
+    }
+
+    /**
+     * 커스텀 URL과 ID로 Link 생성
+     */
+    public static Link createLinkWithUrlAndId(Long id, String url) {
+        return new Link(
+                id,
+                url,
+                TITLE,
+                DESCRIPTION,
+                PREVIEW_IMAGE_URL,
+                null,
+                CONTENT
+        );
+    }
+
+    /**
+     * AI 요약이 포함된 Link 생성
+     */
+    public static Link createLinkWithAiSummary() {
+        Link link = createLink();
+        link.updateAiSummary(AI_SUMMARY);
+        return link;
+    }
+
+    /**
+     * 스크래핑 응답 생성 (정상 케이스)
+     */
+    public static ScrapingResponse createScrapingResponse() {
+        return new ScrapingResponse(
+                true,
+                TITLE,
+                DESCRIPTION,
+                FAVICON_URL,
+                PREVIEW_IMAGE_URL,
+                URL,
+                CONTENT
+        );
+    }
+
+    /**
+     * 스크래핑 응답 생성 (커스텀 URL)
+     */
+    public static ScrapingResponse createScrapingResponse(String url) {
+        return new ScrapingResponse(
+                true,
+                TITLE,
+                DESCRIPTION,
+                FAVICON_URL,
+                PREVIEW_IMAGE_URL,
+                url,
+                CONTENT
+        );
+    }
+
+    /**
+     * 스크래핑 응답 생성 (최소 정보만 - description, content 없음)
+     */
+    public static ScrapingResponse createMinimalScrapingResponse(String url) {
+        return new ScrapingResponse(
+                true,
+                TITLE,
+                null,
+                FAVICON_URL,
+                PREVIEW_IMAGE_URL,
+                url,
+                null
+        );
+    }
+
+    /**
+     * 스크래핑 응답 생성 (빈 제목)
+     */
+    public static ScrapingResponse createScrapingResponseWithEmptyTitle(String url) {
+        return new ScrapingResponse(
+                true,
+                "",
+                DESCRIPTION,
+                FAVICON_URL,
+                PREVIEW_IMAGE_URL,
+                url,
+                CONTENT
+        );
+    }
+}

--- a/src/test/java/swyp12/team9/server/domain/link/fixture/LinkFixture.java
+++ b/src/test/java/swyp12/team9/server/domain/link/fixture/LinkFixture.java
@@ -8,7 +8,6 @@ public class LinkFixture {
     public static final String URL = "https://example.com";
     public static final String TITLE = "테스트 링크 제목";
     public static final String DESCRIPTION = "테스트 링크 설명";
-    public static final String PREVIEW_IMAGE_URL = "https://example.com/preview.jpg";
     public static final String FAVICON_URL = "https://example.com/favicon.ico";
     public static final String CONTENT = "링크 컨텐츠입니다.";
     public static final String AI_SUMMARY = "AI가 생성한 요약 내용입니다.";
@@ -28,17 +27,18 @@ public class LinkFixture {
 
     /**
      * ID가 설정된 Link 생성 (테스트용)
+     * 단위 테스트에서 Mock Repository의 반환값으로 사용
      */
     public static Link createLinkWithId(Long id) {
-        return new Link(
-                id,
-                URL,
-                TITLE,
-                DESCRIPTION,
-                PREVIEW_IMAGE_URL,
-                null,
-                CONTENT
-        );
+        Link link = Link.builder()
+                .url(URL)
+                .title(TITLE)
+                .description(DESCRIPTION)
+                .faviconUrl(FAVICON_URL)
+                .content(CONTENT)
+                .build();
+        setId(link, id);
+        return link;
     }
 
     /**
@@ -58,15 +58,29 @@ public class LinkFixture {
      * 커스텀 URL과 ID로 Link 생성
      */
     public static Link createLinkWithUrlAndId(Long id, String url) {
-        return new Link(
-                id,
-                url,
-                TITLE,
-                DESCRIPTION,
-                PREVIEW_IMAGE_URL,
-                null,
-                CONTENT
-        );
+        Link link = Link.builder()
+                .url(url)
+                .title(TITLE)
+                .description(DESCRIPTION)
+                .faviconUrl(FAVICON_URL)
+                .content(CONTENT)
+                .build();
+        setId(link, id);
+        return link;
+    }
+
+    /**
+     * Reflection을 사용하여 Link 엔티티에 ID 설정
+     * JPA가 자동으로 생성하는 ID를 테스트에서 시뮬레이션하기 위해 사용
+     */
+    private static void setId(Link link, Long id) {
+        try {
+            java.lang.reflect.Field idField = Link.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(link, id);
+        } catch (Exception e) {
+            throw new RuntimeException("ID 설정 실패", e);
+        }
     }
 
     /**
@@ -87,7 +101,6 @@ public class LinkFixture {
                 TITLE,
                 DESCRIPTION,
                 FAVICON_URL,
-                PREVIEW_IMAGE_URL,
                 URL,
                 CONTENT
         );
@@ -102,7 +115,6 @@ public class LinkFixture {
                 TITLE,
                 DESCRIPTION,
                 FAVICON_URL,
-                PREVIEW_IMAGE_URL,
                 url,
                 CONTENT
         );
@@ -117,7 +129,6 @@ public class LinkFixture {
                 TITLE,
                 null,
                 FAVICON_URL,
-                PREVIEW_IMAGE_URL,
                 url,
                 null
         );
@@ -132,7 +143,6 @@ public class LinkFixture {
                 "",
                 DESCRIPTION,
                 FAVICON_URL,
-                PREVIEW_IMAGE_URL,
                 url,
                 CONTENT
         );

--- a/src/test/java/swyp12/team9/server/domain/link/service/LinkServiceTest.java
+++ b/src/test/java/swyp12/team9/server/domain/link/service/LinkServiceTest.java
@@ -1,0 +1,168 @@
+package swyp12.team9.server.domain.link.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import swyp12.team9.server.domain.link.dto.ScrapingResponse;
+import swyp12.team9.server.domain.link.fixture.LinkFixture;
+import swyp12.team9.server.domain.link.model.Link;
+import swyp12.team9.server.domain.link.repository.LinkRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LinkService 단위 테스트")
+class LinkServiceTest {
+
+    @Mock
+    private LinkRepository linkRepository;
+
+    @Mock
+    private ScrapingService scrapingService;
+
+    @Mock
+    private LinkAiService linkAiService;
+
+    @InjectMocks
+    private LinkService linkService;
+
+    @Nested
+    @DisplayName("링크 생성 테스트")
+    class CreateLink {
+
+        @Test
+        @DisplayName("성공: 스크래핑 데이터와 AI 요약 정보를 사용하여 링크를 생성한다")
+        void success() {
+            // given
+            String url = LinkFixture.URL;
+            ScrapingResponse scrapingResponse = LinkFixture.createScrapingResponse(url);
+            String aiSummary = LinkFixture.AI_SUMMARY;
+
+            Link savedLink = LinkFixture.createLinkWithId(1L);
+
+            given(scrapingService.scrapeUrl(anyString(), anyInt())).willReturn(scrapingResponse);
+            given(linkRepository.save(any(Link.class))).willReturn(savedLink);
+            given(linkAiService.summarizeLink(anyString(), anyString(), anyString())).willReturn(aiSummary);
+
+            // when
+            Link result = linkService.createLink(url);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(1L);
+            verify(scrapingService).scrapeUrl(anyString(), anyInt());
+            verify(linkRepository, times(1)).save(any(Link.class));
+            verify(linkAiService).summarizeLink(
+                    scrapingResponse.getTitle(),
+                    scrapingResponse.getDescription(),
+                    scrapingResponse.getContent()
+            );
+        }
+
+        @Test
+        @DisplayName("성공: AI 요약 결과가 null이라도 링크 저장을 완료한다")
+        void success_NullAiSummary() {
+            // given
+            String url = LinkFixture.URL;
+            ScrapingResponse scrapingResponse = LinkFixture.createScrapingResponse(url);
+
+            Link savedLink = LinkFixture.createLinkWithId(1L);
+
+            given(scrapingService.scrapeUrl(anyString(), anyInt())).willReturn(scrapingResponse);
+            given(linkRepository.save(any(Link.class))).willReturn(savedLink);
+            given(linkAiService.summarizeLink(anyString(), anyString(), anyString())).willReturn(null);
+
+            // when
+            Link result = linkService.createLink(url);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(1L);
+            verify(scrapingService).scrapeUrl(anyString(), anyInt());
+            verify(linkRepository, times(1)).save(any(Link.class));
+        }
+
+        @Test
+        @DisplayName("성공: AI 요약 결과가 빈 문자열이어도 링크 생성에 성공한다")
+        void success_EmptyAiSummary() {
+            // given
+            String url = LinkFixture.URL;
+            ScrapingResponse scrapingResponse = LinkFixture.createScrapingResponse(url);
+
+            Link savedLink = LinkFixture.createLinkWithId(1L);
+
+            given(scrapingService.scrapeUrl(anyString(), anyInt())).willReturn(scrapingResponse);
+            given(linkRepository.save(any(Link.class))).willReturn(savedLink);
+            given(linkAiService.summarizeLink(anyString(), anyString(), anyString())).willReturn("");
+
+            // when
+            Link result = linkService.createLink(url);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(1L);
+            verify(scrapingService).scrapeUrl(anyString(), anyInt());
+            verify(linkRepository, times(1)).save(any(Link.class));
+        }
+
+        @Test
+        @DisplayName("성공: 스크래핑 데이터의 모든 필드가 Link 엔티티에 올바르게 매핑되어 저장된다")
+        void success_AllFieldsMapped() {
+            // given
+            String url = LinkFixture.URL;
+            ScrapingResponse scrapingResponse = LinkFixture.createScrapingResponse(url);
+            ArgumentCaptor<Link> linkCaptor = ArgumentCaptor.forClass(Link.class);
+
+            Link savedLink = LinkFixture.createLinkWithId(1L);
+
+            given(scrapingService.scrapeUrl(anyString(), anyInt())).willReturn(scrapingResponse);
+            given(linkRepository.save(linkCaptor.capture())).willReturn(savedLink);
+            given(linkAiService.summarizeLink(anyString(), anyString(), anyString())).willReturn(LinkFixture.AI_SUMMARY);
+
+            // when
+            linkService.createLink(url);
+
+            // then
+            Link capturedLink = linkCaptor.getValue();
+            assertThat(capturedLink.getUrl()).isEqualTo(scrapingResponse.getUrl());
+            assertThat(capturedLink.getTitle()).isEqualTo(scrapingResponse.getTitle());
+            assertThat(capturedLink.getDescription()).isEqualTo(scrapingResponse.getDescription());
+            assertThat(capturedLink.getFaviconUrl()).isEqualTo(scrapingResponse.getFaviconUrl());
+            assertThat(capturedLink.getContent()).isEqualTo(scrapingResponse.getContent());
+        }
+
+        @Test
+        @DisplayName("성공: 최소한의 스크래핑 정보만 있는 경우에도 링크를 생성한다")
+        void success_MinimalInfo() {
+            // given
+            String url = LinkFixture.URL;
+            ScrapingResponse scrapingResponse = LinkFixture.createMinimalScrapingResponse(url);
+
+            Link savedLink = LinkFixture.createLinkWithId(1L);
+
+            given(scrapingService.scrapeUrl(anyString(), anyInt())).willReturn(scrapingResponse);
+            given(linkRepository.save(any(Link.class))).willReturn(savedLink);
+            given(linkAiService.summarizeLink(anyString(), any(), any())).willReturn(null);
+
+            // when
+            Link result = linkService.createLink(url);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(1L);
+            verify(scrapingService).scrapeUrl(anyString(), anyInt());
+            verify(linkRepository, times(1)).save(any(Link.class));
+        }
+    }
+}

--- a/src/test/java/swyp12/team9/server/domain/link/service/LinkServiceTest.java
+++ b/src/test/java/swyp12/team9/server/domain/link/service/LinkServiceTest.java
@@ -135,7 +135,7 @@ class LinkServiceTest {
 
             // then
             Link capturedLink = linkCaptor.getValue();
-            assertThat(capturedLink.getUrl()).isEqualTo(scrapingResponse.getUrl());
+            assertThat(capturedLink.getUrl()).isEqualTo(url);
             assertThat(capturedLink.getTitle()).isEqualTo(scrapingResponse.getTitle());
             assertThat(capturedLink.getDescription()).isEqualTo(scrapingResponse.getDescription());
             assertThat(capturedLink.getFaviconUrl()).isEqualTo(scrapingResponse.getFaviconUrl());

--- a/src/test/java/swyp12/team9/server/domain/reference/fixture/ReferenceFixture.java
+++ b/src/test/java/swyp12/team9/server/domain/reference/fixture/ReferenceFixture.java
@@ -1,0 +1,118 @@
+package swyp12.team9.server.domain.reference.fixture;
+
+import swyp12.team9.server.domain.reference.model.Reference;
+import swyp12.team9.server.domain.user.model.User;
+
+public class ReferenceFixture {
+
+    public static final Long REFERENCE_ID = 1L;
+    public static final String TITLE = "테스트 레퍼런스";
+    public static final String DESCRIPTION = "테스트 설명입니다.";
+    public static final Boolean IS_PUBLIC = true;
+    public static final String COLOR_CODE = "#FF5733";
+    public static final Boolean IS_DEFAULT = false;
+
+    public static final String UPDATED_TITLE = "수정된 레퍼런스";
+    public static final String UPDATED_DESCRIPTION = "수정된 설명입니다.";
+    public static final String UPDATED_COLOR_CODE = "#33FF57";
+
+    /**
+     * 기본 Reference 엔티티 생성
+     */
+    public static Reference createReference(User user) {
+        return Reference.builder()
+                .user(user)
+                .title(TITLE)
+                .description(DESCRIPTION)
+                .isPublic(IS_PUBLIC)
+                .colorCode(COLOR_CODE)
+                .isDefault(IS_DEFAULT)
+                .build();
+    }
+
+    /**
+     * 공개 Reference 생성
+     */
+    public static Reference createPublicReference(User user) {
+        return Reference.builder()
+                .user(user)
+                .title(TITLE)
+                .description(DESCRIPTION)
+                .isPublic(true)
+                .colorCode(COLOR_CODE)
+                .isDefault(false)
+                .build();
+    }
+
+    /**
+     * 비공개 Reference 생성
+     */
+    public static Reference createPrivateReference(User user) {
+        return Reference.builder()
+                .user(user)
+                .title(TITLE)
+                .description(DESCRIPTION)
+                .isPublic(false)
+                .colorCode(COLOR_CODE)
+                .isDefault(false)
+                .build();
+    }
+
+    /**
+     * 기본 미지정 폴더 생성
+     */
+    public static Reference createDefaultReference(User user) {
+        return Reference.builder()
+                .user(user)
+                .title("미지정")
+                .description(null)
+                .isPublic(false)
+                .colorCode(null)
+                .isDefault(true)
+                .build();
+    }
+
+    /**
+     * ID가 설정된 Reference 생성 (테스트용)
+     */
+    public static Reference createReferenceWithId(Long id, User user) {
+        return new Reference(
+                id,
+                user,
+                TITLE,
+                DESCRIPTION,
+                IS_PUBLIC,
+                COLOR_CODE,
+                IS_DEFAULT,
+                null
+        );
+    }
+
+    /**
+     * 커스텀 제목과 공개 여부로 Reference 생성
+     */
+    public static Reference createReferenceWithTitleAndPublic(User user, String title, Boolean isPublic) {
+        return Reference.builder()
+                .user(user)
+                .title(title)
+                .description(DESCRIPTION)
+                .isPublic(isPublic)
+                .colorCode(COLOR_CODE)
+                .isDefault(false)
+                .build();
+    }
+
+    /**
+     * 커스텀 제목으로 Reference 생성
+     */
+    public static Reference createReferenceWithTitle(User user, String title) {
+        return Reference.builder()
+                .user(user)
+                .title(title)
+                .description(DESCRIPTION)
+                .isPublic(IS_PUBLIC)
+                .colorCode(COLOR_CODE)
+                .isDefault(false)
+                .build();
+    }
+}

--- a/src/test/java/swyp12/team9/server/domain/user/fixture/UserFixture.java
+++ b/src/test/java/swyp12/team9/server/domain/user/fixture/UserFixture.java
@@ -1,0 +1,114 @@
+package swyp12.team9.server.domain.user.fixture;
+
+import swyp12.team9.server.domain.user.model.SocialProvider;
+import swyp12.team9.server.domain.user.model.User;
+import swyp12.team9.server.domain.user.model.UserRole;
+import swyp12.team9.server.domain.user.model.UserStatus;
+
+public class UserFixture {
+
+    public static final Long USER_ID = 1L;
+    public static final Long OTHER_USER_ID = 2L;
+
+    public static final String USERNAME = "testuser";
+    public static final String PASSWORD = "password123";
+    public static final String NICKNAME = "테스트유저";
+    public static final String EMAIL = "test@example.com";
+    public static final String INTRODUCTION = "안녕하세요";
+
+    /**
+     * 기본 User 엔티티 생성
+     */
+    public static User createUser() {
+        return User.builder()
+                .username(USERNAME)
+                .password(PASSWORD)
+                .nickname(NICKNAME)
+                .email(EMAIL)
+                .introduction(INTRODUCTION)
+                .isLock(false)
+                .isSocial(false)
+                .socialProvider(null)
+                .roleType(UserRole.USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    /**
+     * ID가 설정된 User 생성 (테스트용)
+     */
+    public static User createUserWithId(Long id) {
+        return new User(
+                id,
+                USERNAME,
+                PASSWORD,
+                false,
+                false,
+                null,
+                UserRole.USER,
+                UserStatus.ACTIVE,
+                NICKNAME,
+                INTRODUCTION,
+                null,
+                null,
+                EMAIL
+        );
+    }
+
+    /**
+     * 다른 사용자 생성 (권한 테스트용)
+     */
+    public static User createOtherUser() {
+        return User.builder()
+                .username("otheruser")
+                .password(PASSWORD)
+                .nickname("다른유저")
+                .email("other@example.com")
+                .introduction(INTRODUCTION)
+                .isLock(false)
+                .isSocial(false)
+                .socialProvider(null)
+                .roleType(UserRole.USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    /**
+     * ID가 설정된 다른 사용자 생성
+     */
+    public static User createOtherUserWithId(Long id) {
+        return new User(
+                id,
+                "otheruser",
+                PASSWORD,
+                false,
+                false,
+                null,
+                UserRole.USER,
+                UserStatus.ACTIVE,
+                "다른유저",
+                INTRODUCTION,
+                null,
+                null,
+                "other@example.com"
+        );
+    }
+
+    /**
+     * 소셜 로그인 사용자 생성
+     */
+    public static User createSocialUser() {
+        return User.builder()
+                .username("socialuser")
+                .password("")
+                .nickname("소셜유저")
+                .email("social@example.com")
+                .introduction(INTRODUCTION)
+                .isLock(false)
+                .isSocial(true)
+                .socialProvider(SocialProvider.KAKAO)
+                .roleType(UserRole.USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+}

--- a/src/test/java/swyp12/team9/server/domain/userlink/fixture/UserLinkFixture.java
+++ b/src/test/java/swyp12/team9/server/domain/userlink/fixture/UserLinkFixture.java
@@ -45,17 +45,30 @@ public class UserLinkFixture {
 
     /**
      * ID가 설정된 Link 생성 (테스트용)
+     * 단위 테스트에서 Mock Repository의 반환값으로 사용
      */
     public static Link createLinkWithId(Long id) {
-        return new Link(
-                id,
-                URL,
-                LINK_TITLE,
-                LINK_DESCRIPTION,
-                null,
-                null,
-                null
-        );
+        Link link = Link.builder()
+                .url(URL)
+                .title(LINK_TITLE)
+                .description(LINK_DESCRIPTION)
+                .build();
+        setId(link, id);
+        return link;
+    }
+
+    /**
+     * Reflection을 사용하여 Link 엔티티에 ID 설정
+     * JPA가 자동으로 생성하는 ID를 테스트에서 시뮬레이션하기 위해 사용
+     */
+    private static void setId(Link link, Long id) {
+        try {
+            java.lang.reflect.Field idField = Link.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(link, id);
+        } catch (Exception e) {
+            throw new RuntimeException("ID 설정 실패", e);
+        }
     }
 
     /**

--- a/src/test/java/swyp12/team9/server/domain/userlink/fixture/UserLinkFixture.java
+++ b/src/test/java/swyp12/team9/server/domain/userlink/fixture/UserLinkFixture.java
@@ -1,0 +1,83 @@
+package swyp12.team9.server.domain.userlink.fixture;
+
+import swyp12.team9.server.domain.link.model.Link;
+import swyp12.team9.server.domain.user.model.User;
+import swyp12.team9.server.domain.userlink.model.LinkStatus;
+import swyp12.team9.server.domain.userlink.model.UserLink;
+
+public class UserLinkFixture {
+
+    public static final Long USER_LINK_ID = 1L;
+    public static final String WHY = "유용한 정보라서 저장했습니다.";
+    public static final String MEMO = "나중에 참고하기 위한 메모입니다.";
+    public static final Boolean IS_PUBLIC = false;
+    public static final Long VIEW_COUNT = 0L;
+
+    public static final String UPDATED_WHY = "수정된 저장 이유입니다.";
+    public static final String UPDATED_MEMO = "수정된 메모입니다.";
+
+    public static final String URL = "https://example.com";
+    public static final String LINK_TITLE = "테스트 링크 제목";
+    public static final String LINK_DESCRIPTION = "테스트 링크 설명";
+
+    /**
+     * 기본 UserLink 엔티티 생성
+     */
+    public static UserLink createUserLink(User user, Link link) {
+        return UserLink.builder()
+                .user(user)
+                .link(link)
+                .why(WHY)
+                .memo(MEMO)
+                .build();
+    }
+
+    /**
+     * 기본 Link 엔티티 생성
+     */
+    public static Link createLink() {
+        return Link.builder()
+                .url(URL)
+                .title(LINK_TITLE)
+                .description(LINK_DESCRIPTION)
+                .build();
+    }
+
+    /**
+     * ID가 설정된 Link 생성 (테스트용)
+     */
+    public static Link createLinkWithId(Long id) {
+        return new Link(
+                id,
+                URL,
+                LINK_TITLE,
+                LINK_DESCRIPTION,
+                null,
+                null,
+                null
+        );
+    }
+
+    /**
+     * 커스텀 URL로 Link 생성
+     */
+    public static Link createLinkWithUrl(String url) {
+        return Link.builder()
+                .url(url)
+                .title(LINK_TITLE)
+                .description(LINK_DESCRIPTION)
+                .build();
+    }
+
+    /**
+     * 커스텀 속성으로 UserLink 생성
+     */
+    public static UserLink createUserLinkWithCustom(User user, Link link, String why, String memo) {
+        return UserLink.builder()
+                .user(user)
+                .link(link)
+                .why(why)
+                .memo(memo)
+                .build();
+    }
+}


### PR DESCRIPTION
 ## 📌 Issues Number
 - closes #30

 ## 📚 Summary
 링크 저장 시 AI를 활용한 자동 요약 기능을 구현했습니다. FastAPI로 구현한 스크래핑 API와 연동하여 링크의 메타데이터(제목, 설명, 파비콘, 컨텐츠)를 수집하고, Spring AI(OpenAI API)를 활용하여 컨텐츠를 3~5문장으로 요약합니다.
LinkService 단위 테스트(5개 테스트 케이스)와 재사용 가능한 Fixture 클래스(4개)를 구현하여 코드 안정성을 확보했습니다.

  ## 🧩 As-is
  - 사용자가 링크를 저장할 때 URL만 저장되고 링크의 내용을 확인하기 위해서는 직접 접속해야 함
  - 링크의 제목, 설명, 아이콘 등 메타데이터 수집 기능이 없어 링크 미리보기 불가
  - 저장된 링크의 핵심 내용을 파악하기 어려워 링크 관리 효율성이 낮음
  - Link 생성 로직에 대한 단위 테스트가 없어 코드 변경 시 안정성 보장이 어려움

  ## 🚀 To-be

  ### 1. 스크래핑 기능 구현
  - 외부 스크래핑 API와 연동하여 링크의 메타데이터 자동 수집
    - 제목(title), 설명(description), 파비콘(favicon), 본문 컨텐츠(content) 추출
        - 유튜브의 경우, 설명=본문, 본문 컨텐츠=자막 
        - 인스타의 경우, 설명=본문, 본문 컨텐츠=댓글 
        - 일반 웹사이트: 설명=짧은 보기 글, 본문 컨텐츠=본문
    - 스크래핑된 원본 URL 저장으로 URL 정규화 이슈 방지
  - RestClient 기반 HTTP 통신 구현 및 인터셉터를 통한 요청/응답 로깅
  - 예외 상황별 처리
    - `LinkInvalidUrlException`: 잘못된 URL 형식
    - `LinkScrapingServerException`: 스크래핑 서버 오류 (5xx)
    - `LinkScrapingTimeoutException`: 스크래핑 타임아웃

  ### 2. AI 요약 기능 구현
  - OpenAI API를 활용한 링크 컨텐츠 자동 요약
    - 제목, 설명, 본문 컨텐츠를 기반으로 3~5문장의 요약 생성
    - 파비콘은 스크래핑 해오지만, AI 요약에서는 사용되지 않음 -> ElasticSearch 추천 시스템에서 사용하도록 함
    - AI 요약 실패 시에도 링크 저장은 정상 처리 (null 허용)
    - 각 단계별 로깅으로 AI 요약 성공/실패 추적 가능
  - Link 엔티티에 `aiSummary` 컬럼 추가 및 `updateAiSummary()` 메서드 구현
  ### 3. Link 엔티티 개선
  - `create()` 정적 팩토리 메서드 추가로 객체 생성 단순화
  - `thumbnailUrl` → `faviconUrl` 컬럼명 변경으로 용도 명확화
  -  `content` 컬럼 추가: 추가적인 정보
  - LinkIndexingService에 컬럼명 변경 반영

  ### 4. LinkService 리팩토링
  - `createLink()` 메서드를 3단계 프로세스로 구조화
    1. 스크래핑 API 호출
    2. Link 생성 및 저장
    3. AI 요약 추가
  - private Helper 메서드로 책임 분리
    - `createLinkFromScrapingData()`: 스크래핑 데이터로 Link 생성 및 저장
    - `addAiSummaryToLink()`: AI 요약 추가 및 업데이트
  - 각 단계별 상세 로깅 (링크 ID, 제목, 성공/실패 여부)

  ### 5. UserLinkService AI 요약 연동
  - UserLink 생성 시 LinkService를 통해 자동으로 AI 요약이 포함된 Link 생성
  - Link 중복 방지 로직과 AI 요약 기능 통합

  ### 6. 인프라 설정
  - `RestClientConfig`: RestClient 빈 등록 (타임아웃 10초 설정)
  - `ScrapingClientInterceptor`: 요청/응답 로깅 인터셉터 (타임아웃 로깅)
  - 필요 환경 변수
    - `scraping.api.url`: 스크래핑 서버 주소
    - `openai.api.key`: OpenAI API 키

  ### 7. 테스트 코드 구현
  - **LinkServiceTest** : LinkService.createLink() 메서드 단위 테스트
    - 정상 시나리오: 스크래핑 + AI 요약 성공
    - AI 요약이 null인 경우 정상 처리 검증
    - AI 요약이 빈 문자열인 경우 정상 처리 검증
    - ArgumentCaptor를 활용한 스크래핑 데이터 필드 매핑 검증
    - 최소 정보만 있는 경우 링크 생성 검증

  - **Fixture 클래스**
    - `LinkFixture`: Link 엔티티, ScrapingResponse 테스트 데이터
    - `UserFixture`: User 엔티티 테스트 데이터
    - `ReferenceFixture`: Reference 엔티티 테스트 데이터
    - `UserLinkFixture`: UserLink 엔티티 테스트 데이터

  - Mockito + BDDMockito를 활용한 given-when-then 패턴 적용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * URL 자동 스크래핑 및 본문 저장으로 링크 정보가 더 풍부해짐
  * AI 기반 요약 생성으로 링크 요약 자동 제공
  * 파비콘(favicon) 지원으로 링크 식별성 향상

* **버그 픽스 / 개선**
  * 잘못된 URL, 서버 오류 및 타임아웃에 대한 처리 및 사용자 피드백 개선
  * 검색/색인 메타데이터에서 파비콘 필드 반영

* **테스트**
  * 링크 생성 및 요약 흐름에 대한 단위/픽스처 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->