### PR TITLE
build: Spring AI 버전 마이그레이션(v1.0.0-M5 -> v1.1.2)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,26 +26,18 @@ configurations {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://repo.spring.io/milestone' }
 }
 
 dependencies {
-	// 1. 아래 constraints 블록을 추가하여 버전을 강제로 맞춥니다.
-	constraints {
-		implementation('io.swagger.core.v3:swagger-annotations:2.2.27') {
-			because 'springdoc-openapi 2.8.3과 호환하는 버전'
-		}
-		implementation('io.swagger.core.v3:swagger-annotations-jakarta:2.2.27')
-		implementation('io.swagger.core.v3:swagger-models-jakarta:2.2.27')
-	}
 
-	// 2. springdoc-openapi 버전도 최신 안정화 버전으로 유지
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3' // 2.7.0에서 2.8.3으로 업그레이드 권장
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 
 	// Valid 검증
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -56,8 +48,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
 	// Spring AI
-	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
-	implementation 'org.springframework.ai:spring-ai-elasticsearch-store-spring-boot-starter'
+	implementation platform("org.springframework.ai:spring-ai-bom:1.1.2")
+	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+	implementation 'org.springframework.ai:spring-ai-starter-vector-store-elasticsearch'
 
 	// AWS SDK for S3 (NCP Object Storage)
 	implementation 'software.amazon.awssdk:s3:2.20.26'
@@ -82,13 +75,6 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
-
-dependencyManagement {
-	imports {
-		mavenBom "org.springframework.ai:spring-ai-bom:1.0.0-M5"
-	}
-}
-
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -102,6 +102,9 @@ spring:
   # google, facebook, github
   # 그래서 따로 google은 추가안해도 된다.
 
+  elasticsearch:
+    uris: ${ELASTICSEARCH_URIS:http://localhost:9200}
+
   ai:
     openai:
       api-key: ${OPENAI_API_KEY} # 환경변수로 설정
@@ -111,8 +114,11 @@ spring:
       embedding:
         options:
           model: text-embedding-3-small
-  elasticsearch:
-    uris: ${ELASTICSEARCH_URIS:http://localhost:9200}
+    vectorstore:
+      elasticsearch:
+        initialize-schema: true
+        dimensions: 1536
+        index-name: keepit-index
 
 logging:
   level:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -103,6 +103,9 @@ spring:
   # google, facebook, github
   # 그래서 따로 google은 추가안해도 된다.
 
+  elasticsearch:
+    uris: ${ELASTICSEARCH_URIS:http://localhost:9200}
+
   ai:
     openai:
       api-key: ${OPENAI_API_KEY} # 환경변수로 설정
@@ -112,8 +115,11 @@ spring:
       embedding:
         options:
           model: text-embedding-3-small
-  elasticsearch:
-    uris: ${ELASTICSEARCH_URIS:http://localhost:9200}
+    vectorstore:
+      elasticsearch:
+        initialize-schema: true
+        dimensions: 1536
+        index-name: keepit-index
 
 logging:
   level:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:dev}
+    active: ${SPRING_PROFILES_ACTIVE:local}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: ${SPRING_PROFILES_ACTIVE:local}
+    active: ${SPRING_PROFILES_ACTIVE:dev}


### PR DESCRIPTION
## 📌 Issues Number
<!--
이 PR과 관련된 이슈 번호를 적어주세요.
예: closes #123, resolves #45
(자동으로 해당 이슈를 닫을 수 있습니다)
-->
- closes #55 
## 📚 Summary
<!--
변경 사항의 요약과 배경을 작성해주세요.
왜 이 변경이 필요한지, 어떤 문제를 해결하는지, 주요 변경 내용을 간략히 기술합니다.
-->
Summary Spring AI 의존성을 기존의 불안정한 개발 버전(Milestone/Snapshot)에서 최신 정식 출시 버전인 v1.1.2 (GA)로 마이그레이션했습니다. 빌드 안정성을 확보하고, Spring AI 팀이 권장하는 최신 네이밍 컨벤션과 표준 설정을 적용했습니다.

## 🧩 As-is
<!--
현재 코드/기능의 문제점이나 개선 전의 동작을 설명해주세요.
예:
- 로그인 실패 시 에러 메시지가 표시되지 않음
- API 응답 속도가 느림
-->

- 불안정한 버전 사용: v1.0.0-M5 등 Milestone/Snapshot 버전을 사용하여 API 변경 위험이 존재함.
- Deprecated 의존성 명칭: spring-ai-openai-spring-boot-starter와 같이 현재 권장되지 않는 구형 Artifact ID를 사용 중.
- 복잡한 저장소 설정: Maven Central 외에 별도의 Milestone/Snapshot 저장소 설정이 필수적

## 🚀 To-be
<!--
변경 후 기대되는 동작이나 개선된 부분을 작성해주세요.
예:
- 로그인 실패 시 에러 메시지 표시됨
- API 응답 속도 30% 향상
-->

- 정식 버전(GA) 적용: Spring AI v1.1.2 로 업그레이드하여 운영 환경 수준의 안정성 확보.
- 표준 네이밍 적용: 공식 문서 권장 사항에 따라 의존성 명칭 변경.
    - spring-ai-openai-spring-boot-starter → spring-ai-starter-openai
    - spring-ai-elasticsearch-store-spring-boot-starter → spring-ai-starter-vector-store-elasticsearch

- 빌드 설정 최적화: build.gradle에서 BOM(Bill of Materials)을 platform 방식으로 변경하고 불필요한 레거시 설정을 제거.
- yaml 설정 변경: Elasticsearch Vector Store 설정에서 인덱스 생성 여부, 인덱스 명 지정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Spring AI 및 OpenAPI 라이브러리 업데이트
  * Elasticsearch 벡터 저장소 설정 추가
  * 기본 개발 프로필 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->