### PR TITLE
hotfix: UserLinkSearchResponse 응답 Dto 수정 

### DIFF
--- a/src/main/java/swyp12/team9/server/api/userlink/UserLinkSearchController.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/UserLinkSearchController.java
@@ -49,7 +49,7 @@ public class UserLinkSearchController implements UserLinkSearchApi {
                     userId, referenceId, keyword, field, cursor);
             response = userLinkSearchService.searchByReference(userId, referenceId, keyword, field, cursor, size);
         } else {
-            // 내 링크 전체에서 검색
+            // 내 링크 전체에서 검색 (홈, 레퍼런스 페이지)
             log.info("내 링크 검색 요청 - userId: {}, keyword: {}, field: {}, cursor: {}", userId, keyword, field, cursor);
             response = userLinkSearchService.searchMyLinks(userId, keyword, field, cursor, size);
         }

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/response/UserLinkListResponse.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/response/UserLinkListResponse.java
@@ -6,9 +6,6 @@ import swyp12.team9.server.domain.reference.model.Reference;
 import swyp12.team9.server.domain.userlink.model.LinkStatus;
 import swyp12.team9.server.domain.userlink.model.UserLink;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Builder
 @Schema(description = "사용자 링크 목록 응답 객체")
 public record UserLinkListResponse(
@@ -16,8 +13,8 @@ public record UserLinkListResponse(
         @Schema(description = "사용자 링크 ID", example = "1")
         Long id,
 
-        @Schema(description = "레퍼런스 정보 목록")
-        List<ReferenceInfo> references,
+        @Schema(description = "레퍼런스 정보")
+        ReferenceInfo reference,
 
         @Schema(description = "링크 제목", example = "디자인 패턴 가이드")
         String title,
@@ -35,14 +32,13 @@ public record UserLinkListResponse(
         Long viewCount
 ) {
 
-    public static UserLinkListResponse of(UserLink userLink, List<Reference> references) {
-        List<ReferenceInfo> referenceInfos = references.stream()
-                .map(ReferenceInfo::from)
-                .collect(Collectors.toList());
+    public static UserLinkListResponse of(UserLink userLink, Reference reference) {
+
+        ReferenceInfo newReference = ReferenceInfo.from(reference);
 
         return UserLinkListResponse.builder()
                 .id(userLink.getId())
-                .references(referenceInfos)
+                .reference(newReference)
                 .title(userLink.getLink().getTitle())
                 .url(userLink.getLink().getUrl())
                 .aiSummary(userLink.getLink().getAiSummary())

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/response/UserLinkResponse.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/response/UserLinkResponse.java
@@ -38,12 +38,6 @@ public record UserLinkResponse(
         Long viewCount
 ) {
 
-    /**
-     * UserLink 엔티티와 Reference 목록으로부터 응답 생성
-     *
-     * @param userLink  UserLink 엔티티
-     * @param reference Reference 엔티티
-     */
     public static UserLinkResponse from(UserLink userLink, Reference reference) {
 
         ReferenceInfo newReference = ReferenceInfo.from(reference);

--- a/src/main/java/swyp12/team9/server/api/userlink/dto/response/UserLinkSearchResponse.java
+++ b/src/main/java/swyp12/team9/server/api/userlink/dto/response/UserLinkSearchResponse.java
@@ -3,7 +3,10 @@ package swyp12.team9.server.api.userlink.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 import lombok.Builder;
+import swyp12.team9.server.domain.reference.model.Reference;
+import swyp12.team9.server.domain.userlink.model.LinkStatus;
 import swyp12.team9.server.domain.userlink.model.UserLink;
 
 /**
@@ -16,7 +19,7 @@ import swyp12.team9.server.domain.userlink.model.UserLink;
 public record UserLinkSearchResponse(
 
         @Schema(description = "검색 결과 목록")
-        List<UserLinkSearchItem> items,
+        List<UserLinkSearchContent> contents,
 
         @Schema(description = "검색어", example = "Spring Boot")
         String keyword,
@@ -31,19 +34,24 @@ public record UserLinkSearchResponse(
     /**
      * List<UserLink>로부터 검색 응답 생성 (커서 기반)
      *
-     * @param userLinks 검색 결과 리스트 (size + 1개 조회됨)
-     * @param keyword   검색에 사용된 키워드
-     * @param size      요청된 페이지 크기
+     * @param userLinks         검색 결과 리스트 (size + 1개 조회됨)
+     * @param keyword           검색에 사용된 키워드
+     * @param size              요청된 페이지 크기
+     * @param referenceResolver UserLink ID로 Reference를 조회하는 함수
      * @return 검색 응답 DTO
      */
-    public static UserLinkSearchResponse from(List<UserLink> userLinks, String keyword, int size) {
+    public static UserLinkSearchResponse from(List<UserLink> userLinks, String keyword, int size,
+                                              Function<Long, Reference> referenceResolver) {
         boolean hasNext = userLinks.size() > size;
 
         // size+1개를 가져왔으므로, 실제 반환은 size개만
         List<UserLink> resultList = hasNext ? userLinks.subList(0, size) : userLinks;
 
-        List<UserLinkSearchItem> items = resultList.stream()
-                .map(userLink -> UserLinkSearchItem.from(userLink, keyword))
+        List<UserLinkSearchContent> contents = resultList.stream()
+                .map(userLink -> {
+                    Reference reference = referenceResolver.apply(userLink.getId());
+                    return UserLinkSearchContent.from(userLink, reference, keyword);
+                })
                 .toList();
 
         // 다음 커서는 마지막 아이템의 ID
@@ -52,7 +60,7 @@ public record UserLinkSearchResponse(
                 : null;
 
         return UserLinkSearchResponse.builder()
-                .items(items)
+                .contents(contents)
                 .keyword(keyword)
                 .nextCursor(nextCursor)
                 .hasNext(hasNext)
@@ -66,7 +74,7 @@ public record UserLinkSearchResponse(
      */
     public static UserLinkSearchResponse empty() {
         return UserLinkSearchResponse.builder()
-                .items(Collections.emptyList())
+                .contents(Collections.emptyList())
                 .keyword("")
                 .nextCursor(null)
                 .hasNext(false)
@@ -74,16 +82,19 @@ public record UserLinkSearchResponse(
     }
 
     /**
-     * 개별 검색 결과 아이템
+     * 개별 검색 결과 내용
      * <p>
-     * 검색어 하이라이팅을 위해 매칭된 필드 정보를 포함합니다.
+     * UserLinkListResponse와 동일한 구조 + 검색어 하이라이팅용 matchedFields
      */
     @Builder
     @Schema(description = "검색 결과 아이템")
-    public record UserLinkSearchItem(
+    public record UserLinkSearchContent(
 
             @Schema(description = "사용자 링크 ID", example = "1")
             Long id,
+
+            @Schema(description = "레퍼런스 정보")
+            ReferenceInfo reference,
 
             @Schema(description = "링크 제목", example = "Spring Boot 가이드")
             String title,
@@ -94,11 +105,8 @@ public record UserLinkSearchResponse(
             @Schema(description = "AI 요약", example = "Spring Boot에 대한 종합 가이드입니다.")
             String aiSummary,
 
-            @Schema(description = "저장 이유", example = "개발 공부용")
-            String why,
-
-            @Schema(description = "메모", example = "핵심 내용 정리 필요")
-            String memo,
+            @Schema(description = "읽음 상태", example = "UNREAD")
+            LinkStatus status,
 
             @Schema(description = "조회수", example = "10")
             Long viewCount,
@@ -110,21 +118,22 @@ public record UserLinkSearchResponse(
         /**
          * UserLink 엔티티로부터 검색 아이템 생성
          *
-         * @param userLink UserLink 엔티티
-         * @param keyword  검색 키워드 (매칭 필드 확인용)
+         * @param userLink  UserLink 엔티티
+         * @param reference Reference 엔티티
+         * @param keyword   검색 키워드 (매칭 필드 확인용)
          * @return 검색 아이템 DTO
          */
-        public static UserLinkSearchItem from(UserLink userLink, String keyword) {
-            // 검색어가 매칭된 필드들을 찾음 (하이라이팅용)
+        public static UserLinkSearchContent from(UserLink userLink, Reference reference, String keyword) {
             List<String> matchedFields = findMatchedFields(userLink, keyword);
+            ReferenceInfo referenceInfo = ReferenceInfo.from(reference);
 
-            return UserLinkSearchItem.builder()
+            return UserLinkSearchContent.builder()
                     .id(userLink.getId())
+                    .reference(referenceInfo)
                     .title(userLink.getLink().getTitle())
                     .url(userLink.getLink().getUrl())
                     .aiSummary(userLink.getLink().getAiSummary())
-                    .why(userLink.getWhy())
-                    .memo(userLink.getMemo())
+                    .status(userLink.getStatus())
                     .viewCount(userLink.getViewCount())
                     .matchedFields(matchedFields)
                     .build();
@@ -132,12 +141,6 @@ public record UserLinkSearchResponse(
 
         /**
          * 검색어가 매칭된 필드들을 찾아 반환
-         * <p>
-         * 프론트엔드에서 검색어 하이라이팅에 활용할 수 있습니다.
-         *
-         * @param userLink UserLink 엔티티
-         * @param keyword  검색 키워드
-         * @return 매칭된 필드명 목록
          */
         private static List<String> findMatchedFields(UserLink userLink, String keyword) {
             if (keyword == null || keyword.isEmpty()) {
@@ -147,7 +150,6 @@ public record UserLinkSearchResponse(
             String lowerKeyword = keyword.toLowerCase();
             java.util.List<String> matched = new java.util.ArrayList<>();
 
-            // 각 필드에서 검색어 매칭 확인
             if (containsIgnoreCase(userLink.getWhy(), lowerKeyword)) {
                 matched.add("why");
             }
@@ -167,9 +169,6 @@ public record UserLinkSearchResponse(
             return matched;
         }
 
-        /**
-         * 대소문자 구분 없이 문자열 포함 여부 확인
-         */
         private static boolean containsIgnoreCase(String text, String keyword) {
             return text != null && text.toLowerCase().contains(keyword);
         }

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkSearchService.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkSearchService.java
@@ -9,6 +9,8 @@ import swyp12.team9.server.api.userlink.dto.response.UserLinkSearchResponse;
 import swyp12.team9.server.domain.reference.exception.ReferenceNotFoundException;
 import swyp12.team9.server.domain.reference.model.Reference;
 import swyp12.team9.server.domain.reference.repository.ReferenceRepository;
+import swyp12.team9.server.domain.referenceuserlink.model.ReferenceUserLink;
+import swyp12.team9.server.domain.referenceuserlink.repository.ReferenceUserLinkRepository;
 import swyp12.team9.server.domain.userlink.model.UserLink;
 import swyp12.team9.server.domain.userlink.repository.UserLinkSearchRepository;
 
@@ -28,6 +30,7 @@ public class UserLinkSearchService {
 
     private final UserLinkSearchRepository userLinkSearchRepository;
     private final ReferenceRepository referenceRepository;
+    private final ReferenceUserLinkRepository referenceUserLinkRepository;
 
     /**
      * 내 링크에서 키워드 검색 (커서 기반)
@@ -59,7 +62,7 @@ public class UserLinkSearchService {
 
         log.info("검색 완료 - 결과: {}건", Math.min(result.size(), size));
 
-        return UserLinkSearchResponse.from(result, normalizedKeyword, size);
+        return UserLinkSearchResponse.from(result, normalizedKeyword, size, this::resolveReference);
     }
 
     /**
@@ -97,7 +100,20 @@ public class UserLinkSearchService {
 
         log.info("레퍼런스 폴더 검색 완료 - 결과: {}건", Math.min(result.size(), size));
 
-        return UserLinkSearchResponse.from(result, normalizedKeyword, size);
+        return UserLinkSearchResponse.from(result, normalizedKeyword, size, this::resolveReference);
+    }
+
+    /**
+     * UserLink ID로 Reference 조회
+     *
+     * @param userLinkId UserLink ID
+     * @return 연결된 Reference (없으면 null)
+     */
+    private Reference resolveReference(Long userLinkId) {
+        return referenceUserLinkRepository.findByUserLinkId(userLinkId).stream()
+                .map(ReferenceUserLink::getReference)
+                .findFirst()
+                .orElse(null);
     }
 
     /**

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
@@ -273,7 +273,7 @@ public class UserLinkService {
     /**
      * UserLink 목록을 UserLinkListResponse로 변환
      *
-     * @param targetReference 조회한 레퍼런스 (null이면 모든 레퍼런스 포함)
+     * @param targetReference 조회한 레퍼런스 (null이면 각 UserLink에 연결된 Reference 조회)
      */
     private PageResponse<UserLinkListResponse> buildUserLinkListResponse(
             List<UserLink> userLinks, int size, Reference targetReference) {
@@ -288,20 +288,19 @@ public class UserLinkService {
 
         List<UserLinkListResponse> responses = content.stream()
                 .map(userLink -> {
-                    List<Reference> references;
+                    Reference reference;
                     if (targetReference != null) {
-                        // referenceId로 조회한 경우, 해당 Reference만 포함
-                        references = List.of(targetReference);
+                        // referenceId로 조회한 경우, 해당 Reference 사용
+                        reference = targetReference;
                     } else {
-                        // 전체 조회인 경우, UserLink에 연결된 모든 Reference 포함
-                        List<ReferenceUserLink> referenceUserLinks = referenceUserLinkRepository.findByUserLinkId(
-                                userLink.getId());
-                        references = referenceUserLinks.stream()
+                        // 전체 조회인 경우, UserLink에 연결된 첫 번째 Reference 조회
+                        reference = referenceUserLinkRepository.findByUserLinkId(userLink.getId()).stream()
                                 .map(ReferenceUserLink::getReference)
-                                .collect(Collectors.toList());
+                                .findFirst()
+                                .orElse(null);
                     }
 
-                    return UserLinkListResponse.of(userLink, references);
+                    return UserLinkListResponse.of(userLink, reference);
                 })
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
## 📌 Issues Number
<!--
이 PR과 관련된 이슈 번호를 적어주세요.
예: closes #123, resolves #45
(자동으로 해당 이슈를 닫을 수 있습니다)
-->
- resolves #65 

## 📚 Summary
<!--
변경 사항의 요약과 배경을 작성해주세요.
왜 이 변경이 필요한지, 어떤 문제를 해결하는지, 주요 변경 내용을 간략히 기술합니다.
-->
- 검색 API 응답 구조(UserLinkSearchResponse)를 목록 조회 API 응답 구조(UserLinkListResponse)와 동일하게 맞추는 리팩토링입니다.                                                                                                                                        
- 프론트엔드에서 검색 결과와 목록 조회 결과를 동일한 방식으로 처리할 수 있도록 일관성을 확보합니다.

## 🧩 As-is
<!--
현재 코드/기능의 문제점이나 개선 전의 동작을 설명해주세요.
예:
- 로그인 실패 시 에러 메시지가 표시되지 않음
- API 응답 속도가 느림
-->
  - 검색 결과 응답 필드: `items` (UserLinkSearchItem)                                                                                                                                                                                                                 
  - UserLinkSearchItem 필드: id, title, url, aiSummary, **why, memo**, viewCount, matchedFields                                                                                                                                                                       
  - Reference 정보 없음, 읽음 상태(status) 없음

## 🚀 To-be
<!--
변경 후 기대되는 동작이나 개선된 부분을 작성해주세요.
예:
- 로그인 실패 시 에러 메시지 표시됨
- API 응답 속도 30% 향상
-->
  - 검색 결과 응답 필드: `contents` (UserLinkSearchContent)                                                                                                                                                                                                           
  - UserLinkSearchContent 필드: id, **reference**, title, url, aiSummary, **status**, viewCount, matchedFields                                                                                                                                                        
  - UserLinkListResponse와 동일한 구조 + matchedFields (검색 전용)                                                                                                                                                                                                    
  - Reference 조회 로직 추가 (ReferenceUserLinkRepository 활용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * 링크 목록 및 검색 결과에서 레퍼런스 정보 처리 방식 개선
  * 검색 결과에 링크 상태(LinkStatus) 및 레퍼런스 정보 추가

* **개선 사항**
  * 링크별 단일 레퍼런스 반환으로 응답 구조 최적화
  * 검색 응답 데이터 모델 재구성으로 더 나은 정보 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->