### PR TITLE
hotfix: 검색 키워드가 카테고리로 표시되는 버그 수정 (AI 카테고리 분류 추가)

### DIFF
--- a/src/main/java/swyp12/team9/server/api/recommendation/RecommendationController.java
+++ b/src/main/java/swyp12/team9/server/api/recommendation/RecommendationController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import swyp12.team9.server.api.recommendation.dto.RecommendationResponse;
 import swyp12.team9.server.domain.link.exception.InvalidCategoryException;
 import swyp12.team9.server.domain.link.model.LinkCategory;
+import swyp12.team9.server.domain.link.service.LinkService;
 import swyp12.team9.server.domain.recommendation.service.LinkIndexingService;
 import swyp12.team9.server.domain.recommendation.service.RecommendationService;
 import swyp12.team9.server.global.annotation.ApiSpec;
@@ -34,107 +35,124 @@ import swyp12.team9.server.global.exception.ErrorCode;
 @RequiredArgsConstructor
 public class RecommendationController {
 
-        private final RecommendationService recommendationService;
-        private final LinkIndexingService linkIndexingService;
+    private final RecommendationService recommendationService;
+    private final LinkIndexingService linkIndexingService;
+    private final LinkService linkService;
 
-        @Operation(summary = "카테고리 목록 조회", description = "탐색 탭에서 사용할 카테고리 목록을 반환합니다. (총 8개 카테고리)")
-        @ApiSpec(status = HttpStatus.OK, errors = {})
-        @GetMapping("/categories")
-        public ApiResponse<List<String>> getCategories() {
-                return ApiResponse.ok(LinkCategory.getAllDisplayNames());
+    @Operation(summary = "카테고리 목록 조회", description = "탐색 탭에서 사용할 카테고리 목록을 반환합니다. (총 8개 카테고리)")
+    @ApiSpec(status = HttpStatus.OK, errors = {})
+    @GetMapping("/categories")
+    public ApiResponse<List<String>> getCategories() {
+        return ApiResponse.ok(LinkCategory.getAllDisplayNames());
+    }
+
+    @Operation(summary = "키워드 검색", description = """
+            검색 키워드를 벡터 유사도 검색하여 관련성 높은 순서로 공개된 링크를 가져옵니다. (키워드는 1~50자 제한)
+            - Elasticsearch 벡터 검색 사용 (OpenAI 임베딩)
+            - 로그인한 사용자의 링크는 자동 제외
+            - 동일 링크는 한 번만 노출
+            - Elasticsearch 장애 시 DB 키워드 검색으로 자동 전환
+            - 응답의 category 필드에 AI가 분류한 링크 카테고리가 포함됩니다
+            """)
+    @ApiSpec(status = HttpStatus.OK, errors = {
+            ErrorCode.VALIDATION_ERROR
+    })
+    @GetMapping("/search")
+    public ApiResponse<List<RecommendationResponse>> searchByKeyword(
+            @CurrentUserId(required = false) Long userId,
+            @Parameter(description = "검색 키워드", example = "프론트엔드 성능 최적화") @RequestParam @NotBlank @Size(min = 1, max = 50) String keyword,
+            @Parameter(description = "가져올 결과 수", example = "10") @RequestParam(defaultValue = "10") @Min(1) @Max(50) int size) {
+        List<RecommendationResponse> searchResults = recommendationService.searchByKeyword(userId, keyword, size);
+        return ApiResponse.ok(searchResults);
+    }
+
+    @Operation(summary = "카테고리별 추천 콘텐츠 조회", description = """
+            카테고리명을 검색어로 유사도 높은 순서로 공개된 링크를 가져옵니다.
+            - Elasticsearch 벡터 검색 사용 (OpenAI 임베딩)
+            - '기타' 카테고리는 다양한 주제의 독특한 콘텐츠를 추천
+            - 로그인한 사용자의 링크는 자동 제외
+            - 동일 링크는 한 번만 노출
+            - Elasticsearch 장애 시 DB 키워드 검색으로 자동 전환
+            - 응답의 category 필드에 AI가 분류한 링크 카테고리가 포함됩니다
+            """)
+    @ApiSpec(status = HttpStatus.OK, errors = {
+            ErrorCode.VALIDATION_ERROR,
+            ErrorCode.INVALID_CATEGORY
+    })
+    @GetMapping
+    public ApiResponse<List<RecommendationResponse>> getRecommendationsByCategory(
+            @CurrentUserId(required = false) Long userId,
+            @Parameter(description = "카테고리명 (미지정 시 전체 조회)", example = "경제/시사") @RequestParam(required = false) String category,
+            @Parameter(description = "가져올 추천 콘텐츠 수", example = "10") @RequestParam(defaultValue = "10") @Min(1) @Max(50) int size) {
+        List<RecommendationResponse> recommendations;
+
+        // 카테고리 미지정 시 전체 최신 공개 링크 반환
+        if (category == null || category.isBlank()) {
+            recommendations = recommendationService.getRecentPublicLinks(userId, size);
+        } else {
+            LinkCategory linkCategory = LinkCategory.fromDisplayName(category)
+                    .orElseThrow(InvalidCategoryException::new);
+
+            // '기타' 카테고리는 혼합 키워드로 벡터 검색 (독특한 콘텐츠 추천)
+            if (linkCategory == LinkCategory.ETC) {
+                String etcKeywords = "독특한 새로운 흥미로운 트렌드 화제";
+                recommendations = recommendationService.getRecommendationsByCategory(userId,
+                        etcKeywords, size);
+            } else {
+                recommendations = recommendationService.getRecommendationsByCategory(userId, category,
+                        size);
+            }
         }
 
-        @Operation(summary = "키워드 검색", description = """
-                        검색 키워드를 벡터 유사도 검색하여 관련성 높은 순서로 공개된 링크를 가져옵니다. (키워드는 1~50자 제한)
-                        - Elasticsearch 벡터 검색 사용 (OpenAI 임베딩)
-                        - 로그인한 사용자의 링크는 자동 제외
-                        - 동일 링크는 한 번만 노출
-                        - Elasticsearch 장애 시 DB 키워드 검색으로 자동 전환
-                        """)
-        @ApiSpec(status = HttpStatus.OK, errors = {
-                        ErrorCode.VALIDATION_ERROR
-        })
-        @GetMapping("/search")
-        public ApiResponse<List<RecommendationResponse>> searchByKeyword(
-                        @CurrentUserId(required = false) Long userId,
-                        @Parameter(description = "검색 키워드", example = "프론트엔드 성능 최적화") @RequestParam @NotBlank @Size(min = 1, max = 50) String keyword,
-                        @Parameter(description = "가져올 결과 수", example = "10") @RequestParam(defaultValue = "10") @Min(1) @Max(50) int size) {
-                List<RecommendationResponse> searchResults = recommendationService.searchByKeyword(userId, keyword,
-                                size);
-                return ApiResponse.ok(searchResults);
-        }
+        return ApiResponse.ok(recommendations);
+    }
 
-        @Operation(summary = "카테고리별 추천 콘텐츠 조회", description = """
-                        카테고리명을 검색어로 유사도 높은 순서로 공개된 링크를 가져옵니다.
-                        - Elasticsearch 벡터 검색 사용 (OpenAI 임베딩)
-                        - '기타' 카테고리는 다양한 주제의 독특한 콘텐츠를 추천
-                        - 로그인한 사용자의 링크는 자동 제외
-                        - 동일 링크는 한 번만 노출
-                        - Elasticsearch 장애 시 DB 키워드 검색으로 자동 전환
-                        """)
-        @ApiSpec(status = HttpStatus.OK, errors = {
-                        ErrorCode.VALIDATION_ERROR,
-                        ErrorCode.INVALID_CATEGORY
-        })
-        @GetMapping
-        public ApiResponse<List<RecommendationResponse>> getRecommendationsByCategory(
-                        @CurrentUserId(required = false) Long userId,
-                        @Parameter(description = "카테고리명 (미지정 시 전체 조회)", example = "경제/시사") @RequestParam(required = false) String category,
-                        @Parameter(description = "가져올 추천 콘텐츠 수", example = "10") @RequestParam(defaultValue = "10") @Min(1) @Max(50) int size) {
-                List<RecommendationResponse> recommendations;
+    @Operation(summary = "[관리자] 전체 링크 색인", description = """
+            DB의 모든 공개 링크를 Elasticsearch에 색인합니다.
+            - 색인 대상: is_public=true인 UserLink
+            - title, aiSummary, why, memo를 통합하여 벡터화
+            - OpenAI API를 통해 임베딩 생성
+            """)
+    @ApiSpec(status = HttpStatus.OK, errors = {
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.ACCESS_DENIED
+    })
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/index")
+    public ApiResponse<String> indexAllLinks() {
+        linkIndexingService.indexAllLinks();
+        return ApiResponse.ok("색인이 완료되었습니다.");
+    }
 
-                // 카테고리 미지정 시 전체 최신 공개 링크 반환
-                if (category == null || category.isBlank()) {
-                        recommendations = recommendationService.getRecentPublicLinks(userId, size);
-                } else {
-                        LinkCategory linkCategory = LinkCategory.fromDisplayName(category)
-                                        .orElseThrow(InvalidCategoryException::new);
+    @Operation(summary = "[관리자] 단일 링크 색인", description = """
+            특정 링크를 참조하는 모든 공개 UserLink를 Elasticsearch에 색인합니다.
+            - 링크 정보 수정 시 재색인용
+            """)
+    @ApiSpec(status = HttpStatus.OK, errors = {
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.ACCESS_DENIED,
+            ErrorCode.LINK_NOT_FOUND
+    })
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/index/link")
+    public ApiResponse<String> indexLink(
+            @Parameter(description = "링크 ID", example = "1") @RequestParam Long linkId) {
+        linkIndexingService.indexLink(linkId);
+        return ApiResponse.ok("링크 ID " + linkId + " 색인이 완료되었습니다.");
+    }
 
-                        // '기타' 카테고리는 혼합 키워드로 벡터 검색 (독특한 콘텐츠 추천)
-                        if (linkCategory == LinkCategory.ETC) {
-                                String etcKeywords = "독특한 새로운 흥미로운 트렌드 화제";
-                                recommendations = recommendationService.getRecommendationsByCategory(userId,
-                                                etcKeywords, size);
-                        } else {
-                                recommendations = recommendationService.getRecommendationsByCategory(userId, category,
-                                                size);
-                        }
-                }
-
-                return ApiResponse.ok(recommendations);
-        }
-
-        @Operation(summary = "[관리자] 전체 링크 색인", description = """
-                        DB의 모든 공개 링크를 Elasticsearch에 색인합니다.
-                        - 색인 대상: is_public=true인 UserLink
-                        - title, aiSummary, why, memo를 통합하여 벡터화
-                        - OpenAI API를 통해 임베딩 생성
-                        """)
-        @ApiSpec(status = HttpStatus.OK, errors = {
-                        ErrorCode.UNAUTHORIZED,
-                        ErrorCode.ACCESS_DENIED
-        })
-        @PreAuthorize("hasRole('ADMIN')")
-        @PostMapping("/index")
-        public ApiResponse<String> indexAllLinks() {
-                linkIndexingService.indexAllLinks();
-                return ApiResponse.ok("색인이 완료되었습니다.");
-        }
-
-        @Operation(summary = "[관리자] 단일 링크 색인", description = """
-                        특정 링크를 참조하는 모든 공개 UserLink를 Elasticsearch에 색인합니다.
-                        - 링크 정보 수정 시 재색인용
-                        """)
-        @ApiSpec(status = HttpStatus.OK, errors = {
-                        ErrorCode.UNAUTHORIZED,
-                        ErrorCode.ACCESS_DENIED,
-                        ErrorCode.LINK_NOT_FOUND
-        })
-        @PreAuthorize("hasRole('ADMIN')")
-        @PostMapping("/index/link")
-        public ApiResponse<String> indexLink(
-                        @Parameter(description = "링크 ID", example = "1") @RequestParam Long linkId) {
-                linkIndexingService.indexLink(linkId);
-                return ApiResponse.ok("링크 ID " + linkId + " 색인이 완료되었습니다.");
-        }
+    @Operation(summary = "[관리자] 전체 링크 카테고리 분류", description = """
+            category가 null인 모든 Link에 대해 AI 카테고리 분류를 수행합니다.
+            - 기존 링크 백필용
+            """)
+    @ApiSpec(status = HttpStatus.OK, errors = {
+            ErrorCode.UNAUTHORIZED,
+            ErrorCode.ACCESS_DENIED
+    })
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/classify-all")
+    public ApiResponse<String> classifyAllLinks() {
+        linkService.classifyAllLinks();
+        return ApiResponse.ok("전체 링크 카테고리 분류가 완료되었습니다.");
+    }
 }

--- a/src/main/java/swyp12/team9/server/api/recommendation/dto/RecommendationResponse.java
+++ b/src/main/java/swyp12/team9/server/api/recommendation/dto/RecommendationResponse.java
@@ -2,6 +2,7 @@ package swyp12.team9.server.api.recommendation.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import swyp12.team9.server.domain.link.model.Link;
+import swyp12.team9.server.domain.link.model.LinkCategory;
 import swyp12.team9.server.domain.userlink.model.UserLink;
 
 /**
@@ -28,13 +29,14 @@ public record RecommendationResponse(
         @Schema(description = "첫 발견자 정보 (가장 먼저 공개 저장한 사용자)")
         UserInfo user
 ) {
-    public static RecommendationResponse from(Link link, UserLink firstUserLink, String category) {
+    public static RecommendationResponse from(Link link, UserLink firstUserLink) {
+        LinkCategory linkCategory = link.getCategory();
         return new RecommendationResponse(
                 link.getId(),
                 link.getUrl(),
                 link.getTitle(),
                 link.getAiSummary(),
-                CategoryInfo.from(category),
+                linkCategory != null ? CategoryInfo.from(linkCategory.getDisplayName()) : null,
                 UserInfo.from(firstUserLink.getUser())
         );
     }

--- a/src/main/java/swyp12/team9/server/domain/link/model/Link.java
+++ b/src/main/java/swyp12/team9/server/domain/link/model/Link.java
@@ -34,6 +34,10 @@ public class Link extends BaseEntity {
     @Column(name = "ai_summary", columnDefinition = "TEXT")
     private String aiSummary;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category")
+    private LinkCategory category;
+
     @Builder
     public Link(String url, String title, String description, String faviconUrl, String content, String aiSummary) {
         this.url = url;
@@ -56,5 +60,9 @@ public class Link extends BaseEntity {
 
     public void updateAiSummary(String aiSummary) {
         this.aiSummary = aiSummary;
+    }
+
+    public void updateCategory(LinkCategory category) {
+        this.category = category;
     }
 }

--- a/src/main/java/swyp12/team9/server/domain/link/model/LinkCategory.java
+++ b/src/main/java/swyp12/team9/server/domain/link/model/LinkCategory.java
@@ -8,8 +8,8 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * 탐색 탭의 고정 카테고리 (검색어로 사용)
- * DB에 저장되지 않으며, Elasticsearch 검색 키워드로만 활용
+ * 탐색 탭의 고정 카테고리
+ * Link 엔티티에 AI 분류 결과로 저장되며, Elasticsearch 검색 키워드로도 활용
  */
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/swyp12/team9/server/domain/link/service/LinkAiService.java
+++ b/src/main/java/swyp12/team9/server/domain/link/service/LinkAiService.java
@@ -6,6 +6,7 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.stereotype.Service;
+import swyp12.team9.server.domain.link.model.LinkCategory;
 
 import java.util.Map;
 
@@ -67,6 +68,64 @@ public class LinkAiService {
         } catch (Exception e) {
             log.error("AI 요약 생성 실패 - title: {}, error: {}", title, e.getMessage(), e);
             return null;
+        }
+    }
+
+    /**
+     * 링크 콘텐츠를 분석하여 가장 적합한 카테고리를 분류합니다.
+     *
+     * @param title       링크 제목
+     * @param description 링크 설명
+     * @param content     링크 콘텐츠 미리보기
+     * @param aiSummary   AI 요약 텍스트
+     * @return 분류된 LinkCategory (실패 시 ETC)
+     */
+    public LinkCategory classifyCategory(String title, String description, String content, String aiSummary) {
+        try {
+            if (isContentInsufficient(title, description, content)) {
+                log.warn("카테고리 분류할 콘텐츠가 부족합니다.");
+                return LinkCategory.ETC;
+            }
+
+            String categoryNames = String.join(", ", LinkCategory.getAllDisplayNames());
+
+            String promptText = """
+                    다음 웹 링크 정보를 분석하여 가장 적합한 카테고리를 하나만 선택해주세요.
+
+                    제목: {title}
+                    설명: {description}
+                    내용: {content}
+                    AI 요약: {aiSummary}
+
+                    카테고리 목록: {categories}
+
+                    규칙:
+                    1. 위 카테고리 목록 중 정확히 하나만 선택
+                    2. 카테고리명만 출력 (다른 텍스트 없이)
+                    3. 적합한 카테고리가 없으면 "기타" 선택
+                    """;
+
+            PromptTemplate promptTemplate = new PromptTemplate(promptText);
+            Prompt prompt = promptTemplate.create(Map.of(
+                    "title", title != null ? title : "제목 없음",
+                    "description", description != null ? description : "설명 없음",
+                    "content", content != null ? content : "내용 없음",
+                    "aiSummary", aiSummary != null ? aiSummary : "요약 없음",
+                    "categories", categoryNames
+            ));
+
+            String result = chatClient.prompt(prompt)
+                    .call()
+                    .content();
+
+            String trimmedResult = result != null ? result.trim() : "";
+            log.info("AI 카테고리 분류 결과: {}", trimmedResult);
+
+            return LinkCategory.fromDisplayName(trimmedResult)
+                    .orElse(LinkCategory.ETC);
+        } catch (Exception e) {
+            log.error("AI 카테고리 분류 실패 - title: {}, error: {}", title, e.getMessage(), e);
+            return LinkCategory.ETC;
         }
     }
 

--- a/src/main/java/swyp12/team9/server/domain/link/service/LinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/link/service/LinkService.java
@@ -6,7 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import swyp12.team9.server.domain.link.dto.ScrapingResponse;
 import swyp12.team9.server.domain.link.model.Link;
+import swyp12.team9.server.domain.link.model.LinkCategory;
 import swyp12.team9.server.domain.link.repository.LinkRepository;
+
+import java.util.List;
 
 
 @Slf4j
@@ -37,6 +40,9 @@ public class LinkService {
 
         // AI 요약 추가 TODO 박현제: AI 요청 로직 비동기로 수정
         addAiSummaryToLink(link, scrapingData);
+
+        // AI 카테고리 분류
+        addCategoryToLink(link, scrapingData);
 
         return link;
     }
@@ -82,5 +88,52 @@ public class LinkService {
         } else {
             log.warn("AI 요약 실패 - linkId: {}", link.getId());
         }
+    }
+
+    /**
+     * Link에 AI 카테고리 분류를 추가합니다.
+     *
+     * @param link 대상 Link
+     * @param scrapingData 스크래핑 데이터
+     */
+    private void addCategoryToLink(Link link, ScrapingResponse scrapingData) {
+        LinkCategory category = linkAiService.classifyCategory(
+                scrapingData.getTitle(),
+                scrapingData.getDescription(),
+                scrapingData.getContent(),
+                link.getAiSummary()
+        );
+
+        link.updateCategory(category);
+        log.info("AI 카테고리 분류 완료 - linkId: {}, category: {}", link.getId(), category);
+    }
+
+    /**
+     * category가 null인 모든 Link에 대해 AI 카테고리 분류를 수행합니다. (관리자 백필용)
+     */
+    @Transactional
+    public void classifyAllLinks() {
+        List<Link> links = linkRepository.findAll().stream()
+                .filter(link -> link.getCategory() == null)
+                .toList();
+
+        log.info("카테고리 미분류 링크 {} 개 백필 시작", links.size());
+
+        for (Link link : links) {
+            try {
+                LinkCategory category = linkAiService.classifyCategory(
+                        link.getTitle(),
+                        link.getDescription(),
+                        link.getContent(),
+                        link.getAiSummary()
+                );
+                link.updateCategory(category);
+                log.info("백필 완료 - linkId: {}, category: {}", link.getId(), category);
+            } catch (Exception e) {
+                log.error("백필 실패 - linkId: {}, error: {}", link.getId(), e.getMessage());
+            }
+        }
+
+        log.info("카테고리 백필 완료 - 처리 건수: {}", links.size());
     }
 }

--- a/src/main/java/swyp12/team9/server/domain/recommendation/service/LinkIndexingService.java
+++ b/src/main/java/swyp12/team9/server/domain/recommendation/service/LinkIndexingService.java
@@ -179,6 +179,7 @@ public class LinkIndexingService {
         metadata.put("why", userLink.getWhy() != null ? userLink.getWhy() : "");
         metadata.put("memo", userLink.getMemo() != null ? userLink.getMemo() : "");
         metadata.put("faviconUrl", link.getFaviconUrl() != null ? link.getFaviconUrl() : "");
+        metadata.put("category", link.getCategory() != null ? link.getCategory().name() : "");
 
         // 3. Document 생성 (ID는 "ul-{userLinkId}" 형식)
         // - 동일 ID로 재색인 시 upsert(업데이트) 동작

--- a/src/main/java/swyp12/team9/server/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/swyp12/team9/server/domain/recommendation/service/RecommendationService.java
@@ -21,11 +21,8 @@ import swyp12.team9.server.domain.userlink.model.UserLink;
 import swyp12.team9.server.domain.userlink.repository.UserLinkRepository;
 
 /**
- * Elasticsearch 벡터 검색 기반 추천 서비스
- * - 링크 데이터(title, aiSummary)를 임베딩하여 Elasticsearch에 저장
- * - 카테고리명을 검색어로 유사도 높은 순서로 링크 반환
- * - 공개 설정된 링크만 추천 대상
- * - 첫 발견자(가장 먼저 공개 저장한 사용자) 정보 포함
+ * Elasticsearch 벡터 검색 기반 추천 서비스 - 링크 데이터(title, aiSummary)를 임베딩하여 Elasticsearch에 저장 - 카테고리명을 검색어로 유사도 높은 순서로 링크 반환 - 공개
+ * 설정된 링크만 추천 대상 - 첫 발견자(가장 먼저 공개 저장한 사용자) 정보 포함
  */
 @Slf4j
 @Service
@@ -37,9 +34,8 @@ public class RecommendationService {
     private final UserLinkRepository userLinkRepository;
 
     /**
-     * 키워드로 링크 검색 (Elasticsearch 벡터 검색)
-     * - 현재 사용자가 이미 저장한 링크는 제외
-     * - Elasticsearch 장애 시 DB fallback 처리
+     * 키워드로 링크 검색 (Elasticsearch 벡터 검색) - 현재 사용자가 이미 저장한 링크는 제외 - Elasticsearch 장애 시 DB fallback 처리 - 응답의 category 필드에
+     * AI가 분류한 링크 카테고리가 포함됩니다
      *
      * @param userId  현재 로그인한 사용자 ID (null 가능)
      * @param keyword 사용자가 입력한 검색 키워드
@@ -91,7 +87,7 @@ public class RecommendationService {
             }
 
             // 4. UserLink 정보를 바탕으로 응답 DTO 생성
-            return buildResponsesFromUserLinkIds(filteredUserLinkIds, keyword);
+            return buildResponsesFromUserLinkIds(filteredUserLinkIds);
 
         } catch (Exception e) {
             // Elasticsearch 장애 시 DB 기반 키워드 검색으로 대체
@@ -101,9 +97,7 @@ public class RecommendationService {
     }
 
     /**
-     * 최신 공개 링크 목록 조회 ('기타' 카테고리용)
-     * - 카테고리가 명확하지 않은 다양한 주제의 링크를 최신순으로 제공
-     * - 현재 사용자가 이미 저장한 링크는 제외
+     * 최신 공개 링크 목록 조회 ('기타' 카테고리용) - 카테고리가 명확하지 않은 다양한 주제의 링크를 최신순으로 제공 - 현재 사용자가 이미 저장한 링크는 제외
      *
      * @param userId 현재 로그인한 사용자 ID (null 가능)
      * @param size   가져올 링크 수
@@ -115,9 +109,8 @@ public class RecommendationService {
     }
 
     /**
-     * 카테고리명을 검색어로 유사도 높은 링크 목록 조회 (Elasticsearch 벡터 검색)
-     * - 현재 사용자가 이미 저장한 링크는 제외 (Pre-filtering)
-     * - Elasticsearch 장애 시 DB fallback 처리
+     * 카테고리명을 검색어로 유사도 높은 링크 목록 조회 (Elasticsearch 벡터 검색) - 현재 사용자가 이미 저장한 링크는 제외 (Pre-filtering) - Elasticsearch 장애 시 DB
+     * fallback 처리
      *
      * @param userId   현재 로그인한 사용자 ID (null 가능)
      * @param category 검색어 (카테고리명 등)
@@ -172,7 +165,7 @@ public class RecommendationService {
             }
 
             // 4. UserLink 정보를 바탕으로 응답 DTO 생성
-            return buildResponsesFromUserLinkIds(filteredUserLinkIds, category);
+            return buildResponsesFromUserLinkIds(filteredUserLinkIds);
 
         } catch (Exception e) {
             // Elasticsearch 장애 시 DB 기반 검색으로 대체
@@ -182,44 +175,48 @@ public class RecommendationService {
     }
 
     /**
-     * UserLink ID 목록으로부터 응답 객체 생성
-     * - DB에서 UserLink 조회 후 요청 순서대로 정렬
-     * - 검색 키워드와 함께 응답 DTO로 변환
-     * 
+     * UserLink ID 목록으로부터 추천 응답 객체 생성
+     *
      * @param userLinkIds 응답에 포함할 UserLink ID 목록 (순서 보장 필요)
-     * @param keyword     검색 키워드 (응답에 포함)
      * @return 추천 링크 응답 목록
      */
-    private List<RecommendationResponse> buildResponsesFromUserLinkIds(List<Long> userLinkIds, String keyword) {
-        List<UserLink> userLinks = userLinkRepository.findAllById(userLinkIds);
-
-        // findAllById는 순서를 보장하지 않으므로, 요청한 ID 순서대로 재정렬
-        Map<Long, UserLink> userLinkMap = userLinks.stream()
-                .collect(Collectors.toMap(UserLink::getId, ul -> ul));
+    private List<RecommendationResponse> buildResponsesFromUserLinkIds(List<Long> userLinkIds) {
+        Map<Long, UserLink> userLinkMap = findUserLinkMapByIds(userLinkIds);
 
         return userLinkIds.stream()
                 .map(userLinkMap::get)
                 .filter(Objects::nonNull)
-                .map(ul -> RecommendationResponse.from(ul.getLink(), ul, keyword))
+                .map(ul -> RecommendationResponse.from(ul.getLink(), ul))
                 .collect(Collectors.toList());
     }
 
     /**
-     * Elasticsearch 메타데이터에서 Long 타입 값 안전하게 추출
-     * - 다양한 Number 타입 변환 처리
-     * 
+     * UserLink ID 목록으로 DB 조회 후 ID → UserLink Map 반환 - findAllById는 순서를 보장하지 않으므로 Map으로 변환하여 호출부에서 순서 보장
+     */
+    private Map<Long, UserLink> findUserLinkMapByIds(List<Long> userLinkIds) {
+        List<UserLink> userLinks = userLinkRepository.findAllById(userLinkIds);
+        return userLinks.stream()
+                .collect(Collectors.toMap(UserLink::getId, ul -> ul));
+    }
+
+    /**
+     * Elasticsearch 메타데이터에서 Long 타입 값 안전하게 추출 - 다양한 Number 타입 변환 처리
+     *
      * @param metadata Elasticsearch 문서의 메타데이터
      * @param key      추출할 필드명
      * @return Long 값 또는 null
      */
     private Long getLongFromMetadata(java.util.Map<String, Object> metadata, String key) {
         Object value = metadata.get(key);
-        if (value == null)
+        if (value == null) {
             return null;
-        if (value instanceof Long)
+        }
+        if (value instanceof Long) {
             return (Long) value;
-        if (value instanceof Number)
+        }
+        if (value instanceof Number) {
             return ((Number) value).longValue();
+        }
         try {
             return Long.parseLong(value.toString());
         } catch (NumberFormatException e) {
@@ -229,7 +226,10 @@ public class RecommendationService {
 
     // ========== Fallback 메서드 (Elasticsearch 장애 시 DB에서 키워드 기반 검색 수행) ==========
 
-    private List<RecommendationResponse> fallbackGetRecentLinks(Long userId, String keyword, int size) {
+    /**
+     * DB에서 키워드 기반으로 공개 UserLink ID 목록을 조회하고 필터링하는 공통 로직
+     */
+    private List<Long> findFallbackUserLinkIds(Long userId, String keyword, int size) {
         // 1. 현재 사용자가 이미 저장한 링크 ID 목록 조회 (중복 추천 방지용)
         List<Long> myLinkIds = userId != null
                 ? userLinkRepository.findLinkIdsByUserId(userId)
@@ -241,7 +241,7 @@ public class RecommendationService {
 
         // 3. 내 링크 제외 및 동일 링크 중복 제거 (가장 최신 UserLink ID만 유지)
         Set<Long> seenLinkIds = new HashSet<>();
-        List<Long> filteredUserLinkIds = publicUserLinks.stream()
+        return publicUserLinks.stream()
                 .filter(ul -> {
                     Long linkId = ul.getLink().getId();
                     if (myLinkIds.contains(linkId) || seenLinkIds.contains(linkId)) {
@@ -253,12 +253,17 @@ public class RecommendationService {
                 .map(UserLink::getId)
                 .limit(size)
                 .collect(Collectors.toList());
+    }
 
+    /**
+     * Fallback (RecommendationResponse 반환)
+     */
+    private List<RecommendationResponse> fallbackGetRecentLinks(Long userId, String keyword, int size) {
+        List<Long> filteredUserLinkIds = findFallbackUserLinkIds(userId, keyword, size);
         if (filteredUserLinkIds.isEmpty()) {
             return Collections.emptyList();
         }
-
-        // 4. 필터링된 UserLink ID 목록을 응답 DTO로 변환하여 반환
-        return buildResponsesFromUserLinkIds(filteredUserLinkIds, keyword);
+        // 필터링된 UserLink ID 목록을 응답 DTO로 변환하여 반환
+        return buildResponsesFromUserLinkIds(filteredUserLinkIds);
     }
 }


### PR DESCRIPTION
## 📌 Issues Number
<!--
이 PR과 관련된 이슈 번호를 적어주세요.
예: closes #123, resolves #45
(자동으로 해당 이슈를 닫을 수 있습니다)
-->
- closes #73 

## 📚 Summary
<!--
변경 사항의 요약과 배경을 작성해주세요.
왜 이 변경이 필요한지, 어떤 문제를 해결하는지, 주요 변경 내용을 간략히 기술합니다.
-->
Link 엔티티에 AI 기반 카테고리 분류 기능을 추가하여,
검색/추천 응답에서 검색 키워드가 아닌 실제 AI 분류 카테고리를 표시하도록 수정했습니다.
- Link 엔티티에 AI 기반 카테고리 분류 추가
- AI 카테고리 분류 및 검색 응답 DTO 통합


주요 변경:
  - Link 엔티티에 `category` 컬럼 추가 (LinkCategory enum, nullable)
  - LinkAiService에 `classifyCategory()` 메서드 추가 (8개 카테고리 중 1개 분류)
  - 링크 생성 시 AI 요약 이후 자동으로 카테고리 분류 수행
  - RecommendationSearchResponse 삭제, RecommendationResponse로 통합
  - 관리자 백필 엔드포인트 추가 (`POST /api/v1/recommendations/classify-all`)


## 🧩 As-is
<!--
현재 코드/기능의 문제점이나 개선 전의 동작을 설명해주세요.
예:
- 로그인 실패 시 에러 메시지가 표시되지 않음
- API 응답 속도가 느림
-->
<img width="2402" height="1636" alt="image" src="https://github.com/user-attachments/assets/a4428112-43a0-4b13-8f8f-263f5f6dddcb" />
<img width="2128" height="1212" alt="image" src="https://github.com/user-attachments/assets/42f1f825-67cb-4a6c-9dc5-559870f46102" />

- Link 엔티티에 카테고리 정보가 없음
- 키워드 검색 시 검색어가 카테고리로 표시되는 버그 발생
- 검색(RecommendationSearchResponse)과 추천(RecommendationResponse) 응답 DTO가 분리되어 있어 일관성 부족




## 🚀 To-be
<!--
변경 후 기대되는 동작이나 개선된 부분을 작성해주세요.
예:
- 로그인 실패 시 에러 메시지 표시됨
- API 응답 속도 30% 향상
-->
  - Link 엔티티에 AI가 분류한 카테고리가 저장됨
  - 검색/추천 모두 동일한 RecommendationResponse를 사용하며, 링크의 실제 카테고리가 표시됨
  - 기존 카테고리 미분류 링크는 관리자 백필 API로 일괄 분류 가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * AI 기반 자동 분류 기능 도입 - 링크가 AI를 통해 자동으로 카테고리 분류됨
  * 관리자 일괄 분류 기능 추가 - 기존의 미분류 링크를 한 번에 분류 가능
  * 카테고리 정보가 권장사항 시스템에 통합되어 더욱 정확한 추천 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->