### PR TITLE
fix: Link 테이블 URL 중복으로 인한 500 에러 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // DB - MySQL Flyway (DB 스키마 변경을 코드처럼 버전 관리해주는 도구)
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql' // MySQL 사용 시
+
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 

--- a/src/main/java/swyp12/team9/server/domain/link/exception/LinkNotFoundException.java
+++ b/src/main/java/swyp12/team9/server/domain/link/exception/LinkNotFoundException.java
@@ -1,0 +1,12 @@
+package swyp12.team9.server.domain.link.exception;
+
+import swyp12.team9.server.global.exception.BusinessException;
+import swyp12.team9.server.global.exception.ErrorCode;
+
+public class LinkNotFoundException extends BusinessException {
+
+    public LinkNotFoundException() {
+        super(ErrorCode.LINK_NOT_FOUND);
+    }
+
+}

--- a/src/main/java/swyp12/team9/server/domain/link/model/Link.java
+++ b/src/main/java/swyp12/team9/server/domain/link/model/Link.java
@@ -6,6 +6,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,10 +29,12 @@ public class Link extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // DB에 prefix UNIQUE 인덱스 적용 (uk_link_url, url(500))
-    // @Column(unique=true)는 VARCHAR(2048)에서 MySQL 키 길이 제한 초과로 사용 불가
     @Column(name = "url", nullable = false, length = 2048)
     private String url;
+
+    // url_hash(SHA-256)로 전체 URL에 대한 UNIQUE 보장
+    @Column(name = "url_hash", nullable = false, length = 64, unique = true)
+    private String urlHash;
 
     @Column(name = "title", length = 300)
     private String title;
@@ -48,6 +54,7 @@ public class Link extends BaseEntity {
     @Builder
     public Link(String url, String title, String description, String faviconUrl, String content, String aiSummary) {
         this.url = url;
+        this.urlHash = generateUrlHash(url);
         this.title = title;
         this.description = description;
         this.faviconUrl = faviconUrl;
@@ -67,5 +74,15 @@ public class Link extends BaseEntity {
 
     public void updateAiSummary(String aiSummary) {
         this.aiSummary = aiSummary;
+    }
+
+    public static String generateUrlHash(String url) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(url.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 algorithm not available", e);
+        }
     }
 }

--- a/src/main/java/swyp12/team9/server/domain/link/model/Link.java
+++ b/src/main/java/swyp12/team9/server/domain/link/model/Link.java
@@ -25,6 +25,8 @@ public class Link extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    // DB에 prefix UNIQUE 인덱스 적용 (uk_link_url, url(500))
+    // @Column(unique=true)는 VARCHAR(2048)에서 MySQL 키 길이 제한 초과로 사용 불가
     @Column(name = "url", nullable = false, length = 2048)
     private String url;
 

--- a/src/main/java/swyp12/team9/server/domain/link/repository/LinkRepository.java
+++ b/src/main/java/swyp12/team9/server/domain/link/repository/LinkRepository.java
@@ -12,9 +12,9 @@ import java.util.Optional;
 public interface LinkRepository extends JpaRepository<Link, Long> {
 
     /**
-     * URL로 Link 조회
+     * URL로 Link 조회 (중복 데이터가 있어도 첫 번째 1건만 반환)
      */
-    Optional<Link> findByUrl(String url);
+    Optional<Link> findFirstByUrl(String url);
 
     /**
      * URL 존재 여부 확인

--- a/src/main/java/swyp12/team9/server/domain/link/repository/LinkRepository.java
+++ b/src/main/java/swyp12/team9/server/domain/link/repository/LinkRepository.java
@@ -12,14 +12,14 @@ import java.util.Optional;
 public interface LinkRepository extends JpaRepository<Link, Long> {
 
     /**
-     * URL로 Link 조회 (중복 데이터가 있어도 첫 번째 1건만 반환)
+     * URL 해시로 Link 조회 (url_hash UNIQUE 인덱스 기반)
      */
-    Optional<Link> findFirstByUrl(String url);
+    Optional<Link> findByUrlHash(String urlHash);
 
     /**
-     * URL 존재 여부 확인
+     * URL 해시 존재 여부 확인
      */
-    boolean existsByUrl(String url);
+    boolean existsByUrlHash(String urlHash);
 
     /**
      * ID 목록에 해당하지 않는 링크 조회 (추천용)

--- a/src/main/java/swyp12/team9/server/domain/link/service/LinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/link/service/LinkService.java
@@ -3,6 +3,7 @@ package swyp12.team9.server.domain.link.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import swyp12.team9.server.domain.link.dto.ScrapingResponse;
 import swyp12.team9.server.domain.link.model.Link;
@@ -25,7 +26,7 @@ public class LinkService {
      * @param url 스크래핑할 URL
      * @return 생성된 Link 엔티티
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Link createLink(String url) {
         log.info("새로운 Link 생성 시작 - URL: {}", url);
 

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +12,7 @@ import swyp12.team9.server.api.userlink.dto.request.UserLinkCreateRequest;
 import swyp12.team9.server.api.userlink.dto.request.UserLinkUpdateRequest;
 import swyp12.team9.server.api.userlink.dto.response.UserLinkListResponse;
 import swyp12.team9.server.api.userlink.dto.response.UserLinkResponse;
+import swyp12.team9.server.domain.link.exception.LinkNotFoundException;
 import swyp12.team9.server.domain.link.model.Link;
 import swyp12.team9.server.domain.link.repository.LinkRepository;
 import swyp12.team9.server.domain.link.service.LinkService;
@@ -62,7 +64,7 @@ public class UserLinkService {
         }
 
         // URL로 기존 Link 조회
-        Link link = linkRepository.findByUrl(request.url()).orElse(null);
+        Link link = linkRepository.findFirstByUrl(request.url()).orElse(null);
 
         // Link가 이미 존재하는 경우, 중복 체크 먼저 수행
         if (link != null && userLinkRepository.existsByUserIdAndLinkId(userId, link.getId())) {
@@ -71,7 +73,14 @@ public class UserLinkService {
 
         // 링크가 없으면 생성
         if (link == null) {
-            link = linkRepository.save(linkService.createLink(request.url()));
+            try {
+                link = linkRepository.save(linkService.createLink(request.url()));
+            } catch (DataIntegrityViolationException e) {
+                // 동시 요청으로 다른 쓰레드가 먼저 같은 URL의 Link를 생성한 경우
+                link = linkRepository.findFirstByUrl(request.url())
+                        .orElseThrow(() -> new LinkNotFoundException());
+                log.info("동시 요청 감지 - 기존 Link 재사용: linkId={}", link.getId());
+            }
         }
 
         // UserLink 생성

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
@@ -75,11 +75,11 @@ public class UserLinkService {
         // 링크가 없으면 생성
         if (link == null) {
             try {
-                link = linkRepository.save(linkService.createLink(request.url()));
+                link = linkService.createLink(request.url());
             } catch (DataIntegrityViolationException e) {
                 // 동시 요청으로 다른 쓰레드가 먼저 같은 URL의 Link를 생성한 경우
                 link = linkRepository.findByUrlHash(urlHash)
-                        .orElseThrow(() -> new LinkNotFoundException());
+                        .orElseThrow(LinkNotFoundException::new);
                 log.info("동시 요청 감지 - 기존 Link 재사용: linkId={}", link.getId());
             }
         }

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
@@ -63,8 +63,9 @@ public class UserLinkService {
             throw new ReferenceSelectionDuplicateException();
         }
 
-        // URL로 기존 Link 조회
-        Link link = linkRepository.findFirstByUrl(request.url()).orElse(null);
+        // URL 해시로 기존 Link 조회
+        String urlHash = Link.generateUrlHash(request.url());
+        Link link = linkRepository.findByUrlHash(urlHash).orElse(null);
 
         // Link가 이미 존재하는 경우, 중복 체크 먼저 수행
         if (link != null && userLinkRepository.existsByUserIdAndLinkId(userId, link.getId())) {
@@ -77,7 +78,7 @@ public class UserLinkService {
                 link = linkRepository.save(linkService.createLink(request.url()));
             } catch (DataIntegrityViolationException e) {
                 // 동시 요청으로 다른 쓰레드가 먼저 같은 URL의 Link를 생성한 경우
-                link = linkRepository.findFirstByUrl(request.url())
+                link = linkRepository.findByUrlHash(urlHash)
                         .orElseThrow(() -> new LinkNotFoundException());
                 log.info("동시 요청 감지 - 기존 Link 재사용: linkId={}", link.getId());
             }

--- a/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
+++ b/src/main/java/swyp12/team9/server/domain/userlink/service/UserLinkService.java
@@ -67,21 +67,26 @@ public class UserLinkService {
         String urlHash = Link.generateUrlHash(request.url());
         Link link = linkRepository.findByUrlHash(urlHash).orElse(null);
 
-        // Link가 이미 존재하는 경우, 중복 체크 먼저 수행
-        if (link != null && userLinkRepository.existsByUserIdAndLinkId(userId, link.getId())) {
-            throw new UserLinkDuplicateException();
-        }
-
         // 링크가 없으면 생성
         if (link == null) {
             try {
                 link = linkService.createLink(request.url());
             } catch (DataIntegrityViolationException e) {
+                // url_hash UNIQUE 제약 위반이 아닌 경우 그대로 전파
+                String message = e.getMostSpecificCause().getMessage();
+                if (message == null || !message.contains("uk_link_url_hash")) {
+                    throw e;
+                }
                 // 동시 요청으로 다른 쓰레드가 먼저 같은 URL의 Link를 생성한 경우
                 link = linkRepository.findByUrlHash(urlHash)
                         .orElseThrow(LinkNotFoundException::new);
                 log.info("동시 요청 감지 - 기존 Link 재사용: linkId={}", link.getId());
             }
+        }
+
+        // UserLink 중복 체크 (기존 Link / 동시 요청으로 재사용한 Link 모두 검사)
+        if (userLinkRepository.existsByUserIdAndLinkId(userId, link.getId())) {
+            throw new UserLinkDuplicateException();
         }
 
         // UserLink 생성

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -12,6 +12,10 @@ spring:
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:password}
 
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
   jpa:
     hibernate:
       ddl-auto: ${DDL_AUTO:update}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -12,6 +12,10 @@ spring:
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:password}
 
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
   jpa:
     hibernate:
       ddl-auto: ${DDL_AUTO:update}

--- a/src/main/resources/db/migration/V20260212__add_unique_url_constraint.sql
+++ b/src/main/resources/db/migration/V20260212__add_unique_url_constraint.sql
@@ -1,0 +1,22 @@
+-- 1. 중복 Link의 user_links 참조를 최소 ID로 통합
+UPDATE user_links ul
+JOIN links l ON ul.link_id = l.id
+JOIN (
+    SELECT url, MIN(id) as keep_id
+    FROM links
+    GROUP BY url
+    HAVING COUNT(*) > 1
+) dup ON l.url = dup.url AND l.id != dup.keep_id
+SET ul.link_id = dup.keep_id;
+
+-- 2. 참조 없는 중복 Link 삭제 (최소 ID만 보존)
+DELETE l FROM links l
+JOIN (
+    SELECT url, MIN(id) as keep_id
+    FROM links
+    GROUP BY url
+    HAVING COUNT(*) > 1
+) dup ON l.url = dup.url AND l.id != dup.keep_id;
+
+-- 3. Prefix UNIQUE 인덱스 추가
+CREATE UNIQUE INDEX uk_link_url ON links (url(500));

--- a/src/main/resources/db/migration/V20260212__add_unique_url_constraint.sql
+++ b/src/main/resources/db/migration/V20260212__add_unique_url_constraint.sql
@@ -18,5 +18,14 @@ JOIN (
     HAVING COUNT(*) > 1
 ) dup ON l.url = dup.url AND l.id != dup.keep_id;
 
--- 3. Prefix UNIQUE 인덱스 추가
-CREATE UNIQUE INDEX uk_link_url ON links (url(500));
+-- 3. url_hash 컬럼 추가
+ALTER TABLE links ADD COLUMN url_hash VARCHAR(64) NULL;
+
+-- 4. 기존 데이터의 url_hash 채우기 (MySQL SHA2 함수 사용)
+UPDATE links SET url_hash = SHA2(url, 256);
+
+-- 5. NOT NULL 제약조건 추가
+ALTER TABLE links MODIFY COLUMN url_hash VARCHAR(64) NOT NULL;
+
+-- 6. UNIQUE 인덱스 추가
+CREATE UNIQUE INDEX uk_link_url_hash ON links (url_hash);

--- a/src/main/resources/db/migration/V20260212__add_unique_url_constraint.sql
+++ b/src/main/resources/db/migration/V20260212__add_unique_url_constraint.sql
@@ -1,13 +1,13 @@
 -- 1. 중복 Link의 user_links 참조를 최소 ID로 통합
 UPDATE user_links ul
-JOIN links l ON ul.link_id = l.id
-JOIN (
+    JOIN links l ON ul.link_id = l.id
+    JOIN (
     SELECT url, MIN(id) as keep_id
     FROM links
     GROUP BY url
     HAVING COUNT(*) > 1
-) dup ON l.url = dup.url AND l.id != dup.keep_id
-SET ul.link_id = dup.keep_id;
+    ) dup ON l.url = dup.url AND l.id != dup.keep_id
+    SET ul.link_id = dup.keep_id;
 
 -- 2. 참조 없는 중복 Link 삭제 (최소 ID만 보존)
 DELETE l FROM links l
@@ -19,13 +19,13 @@ JOIN (
 ) dup ON l.url = dup.url AND l.id != dup.keep_id;
 
 -- 3. url_hash 컬럼 추가
-ALTER TABLE links ADD COLUMN url_hash VARCHAR(64) NULL;
+ALTER TABLE links ADD COLUMN url_hash VARCHAR(64) CHARACTER SET utf8mb4 NULL;
 
 -- 4. 기존 데이터의 url_hash 채우기 (MySQL SHA2 함수 사용)
 UPDATE links SET url_hash = SHA2(url, 256);
 
 -- 5. NOT NULL 제약조건 추가
-ALTER TABLE links MODIFY COLUMN url_hash VARCHAR(64) NOT NULL;
+ALTER TABLE links MODIFY COLUMN url_hash VARCHAR(64) CHARACTER SET utf8mb4 NOT NULL;
 
 -- 6. UNIQUE 인덱스 추가
 CREATE UNIQUE INDEX uk_link_url_hash ON links (url_hash);


### PR DESCRIPTION
## 📌 Issues Number
<!--
이 PR과 관련된 이슈 번호를 적어주세요.
예: closes #123, resolves #45
(자동으로 해당 이슈를 닫을 수 있습니다)
-->
- #83 
- #85 
- #86

## 📚 Summary
<!--
변경 사항의 요약과 배경을 작성해주세요.
왜 이 변경이 필요한지, 어떤 문제를 해결하는지, 주요 변경 내용을 간략히 기술합니다.
-->
- `POST /api/v1/user-links` 호출 시 `links` 테이블에 동일 URL이 여러 건 존재하여 `IncorrectResultSizeDataAccessException` (500 에러)이 발생하는 문제를 수정합니다.
- 기존 `url(500)` prefix UNIQUE 인덱스 방식의 한계를 해결하기 위해, `url_hash`(SHA-256) 컬럼을 추가하여 전체 URL에 대한 완전한 UNIQUE 제약을 보장하도록 변경합니다.
- 동시 요청 처리 시 트랜잭션 문제를 해결하기 위해 Link 생성 트랜잭션을 분리했습니다.

## 🧩 As-is
<!--
현재 코드/기능의 문제점이나 개선 전의 동작을 설명해주세요.
예:
- 로그인 실패 시 에러 메시지가 표시되지 않음
- API 응답 속도가 느림
-->
<img width="3346" height="1818" alt="image" src="https://github.com/user-attachments/assets/637de17f-a457-4933-813d-02ba339a89d3" />

#83
- `links.url` 컬럼에 UNIQUE 제약조건이 없어 동시 요청 시 중복 Link가 생성됨
- `findByUrl(url)`이 동일 URL의 Link 여러 건을 반환하여 500 에러 발생
- `url(500)` prefix 인덱스를 사용하여 URL 앞 500자만 비교
- 앞 500자가 동일하고 뒤쪽만 다른 URL에서 충돌 가능성 존재
- `findFirstByUrl()`로 중복 데이터가 있어도 첫 번째 건만 반환하는 우회 방식 사용

#85 
- `LinkService.createLink()`가 기본 전파(`REQUIRED`)를 사용하여 `UserLinkService`와 같은 트랜잭션에 참여
    - 동시 요청으로 `DataIntegrityViolationException` 발생 시 Hibernate Session이 inconsistent 상태가 됨
    - 트랜잭션이 rollback-only로 마킹되어 catch 블록 이후의 `findByUrlHash()`, `userLinkRepository.save()` 등 모든 DB 작업이 실패
- `UserLinkService`에서 `linkRepository.save(linkService.createLink(...))`로 save를 이중 호출 (LinkService 내부에서 이미 save 수행)

#86 
- 동시 요청 시 `link == null`이면 UserLink 중복 체크를 건너뛰어, 같은 유저에게 동일한 UserLink가 중복 생성될 수 있음
- `DataIntegrityViolationException`을 무조건 url_hash 중복으로 간주하여 다른 제약조건 위반 시 실제 오류가 숨겨짐

## 🚀 To-be
<!--
변경 후 기대되는 동작이나 개선된 부분을 작성해주세요.
예:
- 로그인 실패 시 에러 메시지 표시됨
- API 응답 속도 30% 향상
-->
#83
- Link 생성 시 `DataIntegrityViolationException` catch로 동시 요청 시에도 기존 Link 재사용
- `url_hash` (SHA-256, 64자) 컬럼 추가로 전체 URL에 대한 완전한 UNIQUE 보장
- `findByUrlHash()`로 해시 기반 정확한 단건 조회
- 마이그레이션에서 기존 데이터에 `SHA2(url, 256)` 해시 자동 채움
- Java 표준 `MessageDigest` + `HexFormat` 사용으로 외부 의존성 없음
- Flyway 마이그레이션으로 기존 중복 데이터 정리 및 `uk_link_url_hash` prefix UNIQUE 인덱스 추가

#85 
- `LinkService.createLink()`의 트랜잭션 전파를 `REQUIRES_NEW`로 변경
  - Link 생성이 독립 트랜잭션에서 실행되므로, 실패해도 `UserLinkService`의 트랜잭션에 영향 없음
  - catch 블록에서 정상적으로 `findByUrlHash()` 조회 및 이후 UserLink 저장 가능
- `linkRepository.save()` 이중 호출 제거 (`LinkService` 내부에서 이미 save하므로)

#86 
- UserLink 중복 체크를 Link 확보 이후로 이동하여 모든 경로에서 중복 검사 수행
- `DataIntegrityViolationException` catch 시 `uk_link_url_hash` 제약조건 위반인지 확인 후, 아닌 경우 예외를 그대로 전파


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 데이터베이스 마이그레이션 시스템(Flyway) 추가
  * URL 고유성 보장 메커니즘 구현

* **Bug Fixes**
  * 중복 링크 자동 통합 및 정리
  * 동시 요청 시 중복 생성 방지 로직 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->