### PR TITLE
chore: 로그백 설정 파일 분리 및 환경별 로깅 정책 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // DB - MySQL Flyway (DB 스키마 변경을 코드처럼 버전 관리해주는 도구)
-    implementation 'org.flywaydb:flyway-core'
-    implementation 'org.flywaydb:flyway-mysql' // MySQL 사용 시
+//    implementation 'org.flywaydb:flyway-core'
+//    implementation 'org.flywaydb:flyway-mysql' // MySQL 사용 시
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'

--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // DB - MySQL Flyway (DB 스키마 변경을 코드처럼 버전 관리해주는 도구)
-//    implementation 'org.flywaydb:flyway-core'
-//    implementation 'org.flywaydb:flyway-mysql' // MySQL 사용 시
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql' // MySQL 사용 시
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'

--- a/src/main/java/swyp12/team9/server/ServerApplication.java
+++ b/src/main/java/swyp12/team9/server/ServerApplication.java
@@ -2,10 +2,8 @@ package swyp12.team9.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
 public class ServerApplication {

--- a/src/main/java/swyp12/team9/server/global/config/JpaConfig.java
+++ b/src/main/java/swyp12/team9/server/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package swyp12.team9.server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -145,14 +145,6 @@ ai:
     max-tokens: ${AI_CHATBOT_MAX_TOKENS:2000}  # 챗봇 응답 토큰 제한
     temperature: ${AI_CHATBOT_TEMPERATURE:0.7}  # 챗봇 temperature (자연스러운 대화)
 
-logging:
-  level:
-    root: INFO
-    swyp12.team9: DEBUG
-    org.hibernate.SQL: DEBUG
-    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
-    org.springframework.web: DEBUG
-
 # Frontend URL 설정
 frontend:
   url: ${FRONTEND_URL:http://localhost:3000}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -142,14 +142,8 @@ ai:
   summary:
     temperature: ${AI_SUMMARY_TEMPERATURE:0.4}
   chatbot:
-    max-tokens: ${AI_CHATBOT_MAX_TOKENS:2000}  # 챗봇 응답 토큰 제한
+    max-tokens: ${AI_CHATBOT_MAX_TOKENS:2000} # 챗봇 응답 토큰 제한
     temperature: ${AI_CHATBOT_TEMPERATURE:0.7}
-
-logging:
-  level:
-    root: WARN
-    swyp12.team9: INFO
-    org.hibernate.SQL: WARN
 
 # Frontend URL 설정
 frontend:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name" defaultValue="server"/>
+    <springProperty scope="context" name="LOG_PATH" source="logging.file.path" defaultValue="./logs"/>
+
+    <property name="LOCAL_PATTERN"
+              value="%clr(%d{HH:mm:ss.SSS}){faint} %clr(%-5level) %clr([%thread]){cyan} %clr(%logger{36}){yellow} - %msg%n"/>
+    <property name="DEV_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] [%X{traceId:-}] %logger{36} - %msg%n"/>
+
+    <springProfile name="local">
+        <appender name="CONSOLE_LOCAL" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${LOCAL_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <logger name="swyp12.team9" level="DEBUG"/>
+        <logger name="org.springframework.web" level="DEBUG"/>
+        <logger name="org.hibernate.SQL" level="DEBUG"/>
+        <logger name="org.hibernate.orm.jdbc.bind" level="TRACE"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE_LOCAL"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="dev">
+        <appender name="CONSOLE_DEV" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${DEV_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <appender name="FILE_DEV" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/${APP_NAME}.log</file>
+            <encoder>
+                <pattern>${DEV_PATTERN}</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/${APP_NAME}.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                <maxFileSize>50MB</maxFileSize>
+                <maxHistory>30</maxHistory>
+                <totalSizeCap>2GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <logger name="swyp12.team9" level="INFO"/>
+        <logger name="org.springframework.web" level="INFO"/>
+        <logger name="org.hibernate.SQL" level="WARN"/>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE_DEV"/>
+            <appender-ref ref="FILE_DEV"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!local &amp; !dev">
+        <appender name="CONSOLE_DEFAULT" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>${DEV_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE_DEFAULT"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -57,15 +57,33 @@
         </root>
     </springProfile>
 
-    <springProfile name="!local &amp; !dev">
-        <appender name="CONSOLE_DEFAULT" class="ch.qos.logback.core.ConsoleAppender">
+    <springProfile name="prod">
+        <appender name="CONSOLE_PROD" class="ch.qos.logback.core.ConsoleAppender">
             <encoder>
                 <pattern>${DEV_PATTERN}</pattern>
             </encoder>
         </appender>
 
+        <appender name="FILE_PROD" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${LOG_PATH}/${APP_NAME}.log</file>
+            <encoder>
+                <pattern>${DEV_PATTERN}</pattern>
+            </encoder>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_PATH}/${APP_NAME}.prod.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                <maxFileSize>100MB</maxFileSize>
+                <maxHistory>60</maxHistory>
+                <totalSizeCap>5GB</totalSizeCap>
+            </rollingPolicy>
+        </appender>
+
+        <logger name="swyp12.team9" level="INFO"/>
+        <logger name="org.springframework.web" level="WARN"/>
+        <logger name="org.hibernate.SQL" level="WARN"/>
+
         <root level="INFO">
-            <appender-ref ref="CONSOLE_DEFAULT"/>
+            <appender-ref ref="CONSOLE_PROD"/>
+            <appender-ref ref="FILE_PROD"/>
         </root>
     </springProfile>
 </configuration>


### PR DESCRIPTION
## 📌 Issues Number
closes #98 

## 📚 Summary
애플리케이션의 로깅 시스템을 전용 라이브러리인 Logback으로 교체하고, 실행 환경(Local, Dev)별로 최적화된 로그 출력 및 관리 전략을 구축했다. 로그 설정을 한 곳([logback-spring.xml](cci:7://file:///Users/yangjinmo/Desktop/server/src/main/resources/logback-spring.xml:0:0-0:0))으로 통합하여 유지보수성을 높이고 서버 안정성을 확보하는 것이 목적이다.

## 🧩 As-is
* 각 환경별 YAML([application-local.yaml](cci:7://file:///Users/yangjinmo/Desktop/server/bin/main/application-local.yaml:0:0-0:0), [application-dev.yaml](cci:7://file:///Users/yangjinmo/Desktop/server/bin/main/application-dev.yaml:0:0-0:0)) 파일에 로깅 레벨 설정이 분산되어 있어 일관된 관리가 어려웠다.
* 서버 환경에서 로그 파일의 용량 관리 및 보관 기간에 대한 정의가 없어 디스크 고갈 위험이 존재했다.
* 로컬 개발 시 SQL 쿼리의 바인딩 파라미터(실제 값)를 확인하기 위해 매번 별도의 설정을 추가해야 했다.

## 🚀 To-be
* **설정 단일화:** [logback-spring.xml](cci:7://file:///Users/yangjinmo/Desktop/server/src/main/resources/logback-spring.xml:0:0-0:0) 하나로 모든 로깅 정책을 관리한다.
* **로컬 생산성 향상:** 프로젝트 코드 및 웹 요청에 대한 `DEBUG` 로깅과 SQL 파라미터를 확인할 수 있는 `TRACE` 로깅을 기본 적용한다.
* **운영 안정화:** 개발 서버 로그 파일을 50MB 단위로 롤링하고, 최대 30일/2GB 용량 제한을 두어 시스템 리소스를 보호한다.
* **가독성 개선:** 환경별로 최적화된 로그 패턴(Color, TraceID 등)을 적용한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 로깅 구성을 환경별(로컬, 개발, 기본)으로 최적화하여 디버그 정보 수집 개선
  * 빌드 의존성 정리 및 로깅 설정 업데이트

* **Refactor**
  * JPA 감사(Auditing) 구성을 전용 설정 클래스로 이동하여 초기화 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->