### PR TITLE
chore: CD develop 트리거 제거 제거 및 SSE API 문서화 추가 

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD - App Deploy
 
 on:
   push:
-    branches: [main, develop]
+    branches: main
 
 env:
   GAR_LOCATION: asia-northeast3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,8 @@ name: CD - App Deploy
 
 on:
   push:
-    branches: main
+    branches:
+      - main
 
 env:
   GAR_LOCATION: asia-northeast3

--- a/src/main/java/swyp12/team9/server/domain/sse/controller/SseApi.java
+++ b/src/main/java/swyp12/team9/server/domain/sse/controller/SseApi.java
@@ -1,0 +1,69 @@
+package swyp12.team9.server.domain.sse.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import swyp12.team9.server.global.annotation.ApiSpec;
+import swyp12.team9.server.global.annotation.CurrentUserId;
+import swyp12.team9.server.global.exception.ErrorCode;
+
+/**
+ * SSE(Server-Sent Events) API 인터페이스
+ * 링크 처리 결과를 실시간으로 클라이언트에 전달하는 API 스펙 정의
+ */
+@Tag(name = "SSE", description = "실시간 이벤트 스트림 API - 링크 처리 완료/실패 알림")
+@RequestMapping("/api/v1/sse")
+public interface SseApi {
+
+    @Operation(
+            summary = "SSE 이벤트 구독",
+            description = """
+                    서버의 실시간 이벤트를 구독합니다. (Server-Sent Events)
+
+                    **연결 정보:**
+                    - 타임아웃: 30분
+                    - 유저당 최대 동시 연결: 5개 (초과 시 가장 오래된 연결 자동 종료)
+                    - 연결 즉시 `CONNECT` 이벤트로 연결 확인 메시지가 전송됩니다
+
+                    **수신 가능한 이벤트:**
+
+                    1. `CONNECT` - 연결 성공 확인
+                    ```
+                    event: CONNECT
+                    data: Connected successfully.
+                    ```
+
+                    2. `link_completed` - 링크 처리(스크래핑 + AI 요약) 완료
+                    ```json
+                    event: link_completed
+                    data: {"userLinkId": 1, "linkId": 1, "title": "링크 제목", "status": "COMPLETED"}
+                    ```
+
+                    3. `link_failed` - 링크 처리 실패
+                    ```json
+                    event: link_failed
+                    data: {"userLinkId": 1, "linkId": 1, "status": "FAILED", "reason": "실패 사유"}
+                    ```
+                    """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "SSE 스트림 연결 성공",
+                            content = @Content(mediaType = MediaType.TEXT_EVENT_STREAM_VALUE)
+                    )
+            }
+    )
+    @ApiSpec(
+            errors = {
+                    ErrorCode.UNAUTHORIZED
+            }
+    )
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    ResponseEntity<SseEmitter> subscribe(@CurrentUserId Long userId);
+}

--- a/src/main/java/swyp12/team9/server/domain/sse/controller/SseController.java
+++ b/src/main/java/swyp12/team9/server/domain/sse/controller/SseController.java
@@ -1,9 +1,7 @@
 package swyp12.team9.server.domain.sse.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -13,14 +11,11 @@ import swyp12.team9.server.global.annotation.CurrentUserId;
 @RestController
 @RequestMapping("/api/v1/sse")
 @RequiredArgsConstructor
-public class SseController {
+public class SseController implements SseApi {
 
     private final SseEmitterService sseEmitterService;
 
-    /**
-     * 클라이언트가 서버의 이벤트를 구독(SSE 연결 수립)합니다.
-     */
-    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    @Override
     public ResponseEntity<SseEmitter> subscribe(@CurrentUserId Long userId) {
         SseEmitter emitter = sseEmitterService.subscribe(userId);
         return ResponseEntity.ok(emitter);


### PR DESCRIPTION
## 📌 Issues Number
<!--
이 PR과 관련된 이슈 번호를 적어주세요.
예: closes #123, resolves #45
(자동으로 해당 이슈를 닫을 수 있습니다)
-->
- #95 
- #104 
## 📚 Summary
<!--
변경 사항의 요약과 배경을 작성해주세요.
왜 이 변경이 필요한지, 어떤 문제를 해결하는지, 주요 변경 내용을 간략히 기술합니다.
-->
배포 스크립트에 develop 배포 트리거 제거 및 SSE API 문서화를 추가했습니다.

## 🧩 As-is
<!--
현재 코드/기능의 문제점이나 개선 전의 동작을 설명해주세요.
예:
- 로그인 실패 시 에러 메시지가 표시되지 않음
- API 응답 속도가 느림
-->
- cd.yml 배포 스크립트에 main, develop 모두 명시
- SSE API 문서화가 되어있지 않음
## 🚀 To-be
<!--
변경 후 기대되는 동작이나 개선된 부분을 작성해주세요.
예:
- 로그인 실패 시 에러 메시지 표시됨
- API 응답 속도 30% 향상
-->
- cd.yml 배포 스크립트에 main만 명시함으로써, develop 브랜치에서는 배포가 트리거 되지 않도록 함
- SSE API 문서 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Server-Sent Events (SSE) 구독 기능 추가: `/api/v1/sse/subscribe` 엔드포인트를 통해 실시간 이벤트 스트리밍 지원 (연결 완료, 실패 등 이벤트 포함)

* **작업**
  * CI/CD 배포 워크플로우 최적화: main 브랜치 푸시 시에만 자동 배포 실행

<!-- end of auto-generated comment: release notes by coderabbit.ai -->